### PR TITLE
RLM-216 Remove Horizon logo files variable

### DIFF
--- a/pre_leap.sh
+++ b/pre_leap.sh
@@ -34,3 +34,15 @@ pushd $OSA_PATH
         exit 1
     fi
 popd
+
+# Remove horizon static files variables from user_variables.yml as this is now
+# maintained in group_vars.
+if grep '^rackspace_static_files_folder\:' /etc/openstack_deploy/user_variables.yml; then
+  sed -i '/^rackspace_static_files_folder:.*/d' /etc/openstack_deploy/user_variables.yml
+fi
+
+# Remove horizon_custom_uploads block from user_variables.yml as this is maintained in
+# group_vars
+if grep '^horizon_custom_uploads\:' /etc/openstack_deploy/user_variables.yml; then
+  sed -i '/horizon_custom_uploads:/,/src:.*logo-splash.png/d' /etc/openstack_deploy/user_variables.yml
+fi


### PR DESCRIPTION
Remove the Horizon logo files vars from user_varables.yml
since they are now maintained in group_vars and represent
the outdated location of the logo files.