### PR TITLE
Add series specific variable overrides for leapfrogging

### DIFF
--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -17,4 +17,15 @@
 export VALIDATE_UPGRADE_INPUT=false
 export AUTOMATIC_VAR_MIGRATE_FLAG="--for-testing-take-new-vars-only"
 
+if [ "${IRR_SERIES}" == "kilo" ]; then
+  export RPC_TARGET_CHECKOUT="r14.2.0"
+  export OA_OPS_REPO_BRANCH="50f3fd6df7579006748a00c271bb03d22b17ae89"
+elif [ "${IRR_SERIES}" == "liberty" ]; then
+  export RPC_TARGET_CHECKOUT="newton"
+  export OA_OPS_REPO_BRANCH="0690bb608527b90596e5522cc852ffa655228807"
+elif [ "${IRR_SERIES}" == "mitaka" ]; then
+  export RPC_TARGET_CHECKOUT="newton"
+  export OA_OPS_REPO_BRANCH="0690bb608527b90596e5522cc852ffa655228807"
+fi
+  
 sudo --preserve-env $(readlink -e $(dirname ${0}))/../scripts/ubuntu14-leapfrog.sh


### PR DESCRIPTION
Allows for setting specific series variables for the leapfrog script to set the target RPC branch and the desired OSA-OPs repo.