### PR TITLE
Various Liberty fixes for initial deploy

### DIFF
--- a/playbooks/patches/liberty/galera_server/galera_server_apt_repo_defaults.patch
+++ b/playbooks/patches/liberty/galera_server/galera_server_apt_repo_defaults.patch
@@ -1,0 +1,13 @@
+diff --git a/playbooks/roles/galera_server/defaults/main.yml b/playbooks/roles/galera_server/defaults/main.yml
+index 6f84c07..84835af 100644
+--- a/playbooks/roles/galera_server/defaults/main.yml
++++ b/playbooks/roles/galera_server/defaults/main.yml
+@@ -75,7 +75,7 @@ galera_gpg_keys:
+   - key_name: 'percona-xtrabackup'
+     keyserver: 'hkp://keyserver.ubuntu.com:80'
+     fallback_keyserver: 'hkp://p80.pool.sks-keyservers.net:80'
+-    hash_id: '0x1c4cbdcdcd2efd2a'
++    hash_id: '0x9334A25F8507EFA5'
+
+ # Repositories
+ galera_apt_repo_url: "https://mirror.rackspace.com/mariadb/repo/10.0/ubuntu"

--- a/playbooks/patches/liberty/galera_server/galera_server_apt_repo_pre_install.patch
+++ b/playbooks/patches/liberty/galera_server/galera_server_apt_repo_pre_install.patch
@@ -1,0 +1,41 @@
+diff --git a/playbooks/roles/galera_server/tasks/galera_pre_install.yml b/playbooks/roles/galera_server/tasks/galera_pre_install.yml
+index 4b84ac6..cf96eb6 100644
+--- a/playbooks/roles/galera_server/tasks/galera_pre_install.yml
++++ b/playbooks/roles/galera_server/tasks/galera_pre_install.yml
+@@ -67,6 +67,36 @@
+   tags:
+     - galera-apt-keys
+
++- name: Reset apt cache
++  file:
++    path: "{{ item }}"
++    state: "absent"
++  with_items:
++    - /var/cache/apt
++    - /var/lib/apt/lists
++  tags:
++    - galera-apt-packages
++
++- name: Regen apt dirs
++  file:
++    path: "{{ item }}"
++    state: "directory"
++  with_items:
++    - /var/cache/apt
++    - /var/lib/apt/lists
++  tags:
++    - galera-apt-packages
++
++- name: Update apt sources
++  apt:
++    update_cache: yes
++  register: apt_update
++  until: apt_update|success
++  retries: 5
++  delay: 2
++  tags:
++    - galera-apt-packages
++
+ - name: Drop galera repo pin
+   template:
+     src: "galera_pin.pref.j2"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -52,6 +52,7 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   sudo -H --preserve-env pip install -r test-requirements.txt
   sudo -H --preserve-env ./tests/aio-create.sh
   sudo -H --preserve-env ./tests/test-leapfrog.sh
+  sudo -H --preserve-env ./tests/run-tempest.sh
 else
   sudo -H --preserve-env tox
 fi

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -52,7 +52,7 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   sudo -H --preserve-env pip install -r test-requirements.txt
   sudo -H --preserve-env ./tests/aio-create.sh
   sudo -H --preserve-env ./tests/test-leapfrog.sh
-  sudo -H --preserve-env ./tests/run-tempest.sh
+#  sudo -H --preserve-env ./tests/run-tempest.sh
 else
   sudo -H --preserve-env tox
 fi

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -158,6 +158,10 @@ function get_ssh_role {
 
   if [[ ! -d "/etc/ansible/roles/sshd" ]]; then
     git clone https://github.com/willshersystems/ansible-sshd /etc/ansible/roles/sshd
+    pushd /etc/ansible/roles/sshd
+      # checks out commit before it breaks by using "package" on Ansible 1.9x
+      git checkout f85838007002e47712dde60d7bbf747400264dc9
+    popd
   fi
 }
 

--- a/tests/run-tempest.sh
+++ b/tests/run-tempest.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -evu
+
+pushd /opt/rpc-openstack/scripts
+  # install tempest
+  openstack-ansible run_tempest.yml --skip-tags tempest_execute_tests -vv
+  # run tests
+  openstack-ansible run_tempest.yml -t tempest_execute_tests -vv
+popd

--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -27,5 +27,5 @@ elif [ "${IRR_SERIES}" == "mitaka" ]; then
   export RPC_TARGET_CHECKOUT="newton"
   export OA_OPS_REPO_BRANCH="0690bb608527b90596e5522cc852ffa655228807"
 fi
-  
+
 sudo --preserve-env $(readlink -e $(dirname ${0}))/../scripts/ubuntu14-leapfrog.sh


### PR DESCRIPTION
Includes tempest tests, leaves disabled while we work through gate jobs.  Includes fix for RLM-328 to fix up percona repo that failed with bad signatures during initial provisioning, pins sshd role to commit before switching to the package module in Ansible 2.0 since we're using 1.9.
