### PR TITLE
RE-913 Add support for minor upgrades

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -61,7 +61,7 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   else
     sudo -H --preserve-env ./tests/aio-create.sh
   fi
-  sudo -H --preserve-env ./tests/test-leapfrog.sh
+  sudo -H --preserve-env ./tests/test-upgrade.sh
 #  sudo -H --preserve-env ./tests/run-tempest.sh
 else
   sudo -H --preserve-env tox

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -51,7 +51,7 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   sudo -H --preserve-env ./run-bindep.sh
   sudo -H --preserve-env pip install -r test-requirements.txt
   sudo -H --preserve-env ./tests/aio-create.sh
-  sudo -H --preserve-env ./tests/test-leapfrog.sh
+  sudo -H --preserve-env ./tests/test-upgrade.sh
 #  sudo -H --preserve-env ./tests/run-tempest.sh
 else
   sudo -H --preserve-env tox

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -90,7 +90,7 @@ function set_gating_vars {
   # NOTE(cloudnull): Set variables to ensure AIO gate success.
   _ensure_osa_dir
 
-  cat > /etc/openstack_deploy/user_rpco_leap.yml <<EOF
+  cat > /etc/openstack_deploy/user_rpco_upgrade.yml <<EOF
 ---
 neutron_legacy_ha_tool_enabled: true
 lxc_container_backing_store: dir
@@ -251,6 +251,16 @@ pushd /opt/rpc-openstack
     unset_affinity
     allow_frontloading_vars
     rpco_exports
+  elif [ "${RE_JOB_SERIES}" == "newton" ]; then
+    git_checkout "newton"  # Last commit of Newton
+    (git submodule init && git submodule update) || true
+
+    # NOTE(cloudnull): Run Newton pre-setup functions
+    pin_jinja
+    pin_galera "10.0"
+    unset_affinity
+    allow_frontloading_vars
+    rpco_exports
   else
     if ! git_checkout ${RE_JOB_SERIES}; then
       echo "FAIL!"
@@ -273,7 +283,7 @@ pushd /opt/rpc-openstack
   # Disable the sec role
   disable_security_role
 
-  # Run the leapfrog job with gate specific vars
+  # Run the upgrade job with gate specific vars
   set_gating_vars
 
   # Setup an AIO

--- a/tests/test-minor.sh
+++ b/tests/test-minor.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+pushd /opt/rpc-openstack
+  git clean -df
+  git reset --hard HEAD
+  git checkout ${RE_JOB_UPGRADE_TO}
+  (git submodule init && git submodule update) || true
+  scripts/deploy.sh
+popd

--- a/tests/test-upgrade.sh
+++ b/tests/test-upgrade.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ "${RE_JOB_UPGRADE_ACTION}" == "leap" ]; then
+  tests/test-leapfrog.sh
+elif [ "${RE_JOB_UPGRADE_ACTION}" == "minor" ]; then
+  tests/test-minor.sh
+else
+  echo "FAIL!"
+  echo "RE_JOB_UPGRADE_ACTION '${RE_JOB_UPGRADE_ACTION}' is not supported."
+  exit 99
+fi


### PR DESCRIPTION
The current minor upgrade path simply involves running the newer version
of the deployment script, there is no specific upgrade code path to run.

This change introduces `tests/test-minor.sh` for running a minor upgrade
and `tests/test-upgrade.sh` for controlling which type of upgrade is
performed. If RE_JOB_UPGRADE_ACTION is either "leap" or "minor" the
appropriate script is executed.

`tests/aio-create.sh` is updated to support deploying a newton version
of the code as the base so that minor upgrades on the current release
can be tested.