### PR TITLE
RLM-305 Enable MaaS Deploy and Verify before Leap

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -64,6 +64,7 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   else
     sudo -H --preserve-env ./tests/aio-create.sh
   fi
+  sudo -H --preserve-env ./tests/maas-install.sh
   sudo -H --preserve-env ./tests/test-upgrade.sh
 #  sudo -H --preserve-env ./tests/run-tempest.sh
 else

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,0 +1,45 @@
+[defaults]
+gathering = smart
+host_key_checking = False
+
+# Setting forks should be based on your system. The Ansible defaults to 5,
+# the os-lxc-hosts assumes that you have a system that can support
+# OpenStack, thus it has been conservatively been set to 15
+forks = 15
+
+# SSH timeout
+timeout = 120
+
+# Set the path to the folder in openstack-ansible which holds the dynamic
+# inventory script - new config setting for ansible v1.9 and above
+inventory = /opt/rpc-openstack/openstack-ansible/playbooks/inventory/
+
+# Set the path to the folder in openstack-ansible which holds the dynamic
+# inventory script - uncomment if using ansible below v1.9
+#hostfile = ../../openstack-ansible/playbooks/inventory/
+
+# Set the path to the folder in openstack-ansible which holds the
+# libraries required
+library = /opt/rpc-openstack/openstack-ansible/playbooks/library/
+
+# Set the path to the folder in openstack-ansible which holds the roles
+# that are depended on by the rpc-openstack roles
+roles_path = /opt/rpc-openstack/openstack-ansible/playbooks/roles/:/etc/ansible/roles/
+
+# Set the path to the folder in openstack-ansible which holds the
+# lookup plugins required
+lookup_plugins = /opt/rpc-openstack/openstack-ansible/playbooks/plugins/lookups/
+
+# Set the path to the folder in openstack-ansible which holds the filter
+# plugins required
+filter_plugins = /opt/rpc-openstack/openstack-ansible/playbooks/plugins/filters/
+
+# Set the path to the folder in openstack-ansible which holds the action
+# plugins required
+action_plugins = /opt/rpc-openstack/openstack-ansible/playbooks/plugins/actions/
+
+# Enable playbook callbacks from OSA to display playbook statistics
+callback_plugins = /opt/rpc-openstack/openstack-ansible/playbooks/plugins/callbacks
+
+[ssh_connection]
+pipelining = True

--- a/playbooks/maas-get.yml
+++ b/playbooks/maas-get.yml
@@ -1,0 +1,34 @@
+---
+# Copyright 2014, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Clone MaaS
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Clone RPC-MaaS
+      git:
+        repo: "https://github.com/rcbops/rpc-maas"
+        dest: "/opt/rpc-maas"
+        version: "{{ maas_release }}"
+    - name: Ensure openstack_deploy exists
+      file:
+        dest: "/etc/openstack_deploy"
+        state: directory
+    - name: Copy over base maas vars
+      copy:
+        src: "/opt/rpc-maas/tests/user_liberty_vars.yml"
+        dest: "/etc/openstack_deploy/user_rpcm_default_variables.yml"
+  tags:
+    - maas

--- a/playbooks/maas-setup.yml
+++ b/playbooks/maas-setup.yml
@@ -1,0 +1,17 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- include: maas-get.yml
+- include: /opt/rpc-maas/playbooks/site.yml

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -94,6 +94,8 @@ function set_gating_vars {
 ---
 neutron_legacy_ha_tool_enabled: true
 lxc_container_backing_store: dir
+maas_use_api: false
+maas_release: master
 EOF
 }
 

--- a/tests/maas-install.sh
+++ b/tests/maas-install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -evu
+
+pushd /opt/rpc-upgrades/playbooks
+  # install maas
+  openstack-ansible maas-setup.yml -vv
+  # verify maax is running
+  openstack-ansible /opt/rpc-maas/playbooks/maas-verify.yml -vv
+popd


### PR DESCRIPTION
Deploys and verifies MaaS after deploy of AIO and before leapfrog.  

Uses playbooks in the repo copied from head rpc-openstack to checkout rpc-maas repo.  The older point releases of the various versions have the old maas release built in and is not using the rpc-maas repo.  Since the rpc-maas repo is our current preferred method, this runs and installs maas from there.