### PR TITLE
RLM-306 Run maas-verify after leapfrog

### DIFF
--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -29,3 +29,10 @@ elif [ "${RE_JOB_SERIES}" == "mitaka" ]; then
 fi
 
 sudo --preserve-env $(readlink -e $(dirname ${0}))/../scripts/ubuntu14-leapfrog.sh
+
+# if rpc-maas repo exists, run maas-verify
+if [ -d "/opt/rpc-maas" ]; then
+  pushd /opt/rpc-upgrades/playbooks
+    openstack-ansible maas-verify.yml -vv
+  popd
+fi


### PR DESCRIPTION
Runs maas-verify after leapfrog if /opt/rpc-maas exists.

Depends on https://github.com/rcbops/rpc-upgrades/pull/28