### PR TITLE
[RLM-431] Update local testing to use gating vars

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,71 +7,58 @@
 ########################################
 
 # Verify whether required plugins are installed.
-required_plugins = [ "vagrant-disksize" ]
+required_plugins = [ "vagrant-cachier", "vagrant-disksize" ]
 required_plugins.each do |plugin|
   if not Vagrant.has_plugin?(plugin)
     raise "The vagrant plugin #{plugin} is required. Please run `vagrant plugin install #{plugin}`"
   end
 end
 
+# Configure Job Actions the way gating would pass them
+job_actions = [
+  "kilo_to_newton_leap",
+  "kilo_to_r14.2.0_leap",
+  "liberty_to_newton_leap",
+  "r12.2.8_to_r14.4.1_leap",
+  "r12.1.2_to_r14.4.1_leap",
+  "r12.2.2_to_r14.4.1_leap",
+  "r12.2.5_to_r14.4.1_leap",
+]
+
 Vagrant.configure("2") do |config|
-  config.vm.provider "virtualbox" do |v|
-    v.memory = 16384
-    v.cpus = 4
+  config.vm.provider "virtualbox" do |provider|
+    provider.memory = 16384
+    provider.cpus = 4
   end
+
+  # Configure the box
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.box_check_update = false
 
   # Configure the disk size.
-  disk_size = "100GB"
+  config.disksize.size = "100GB"
 
-  ### vagrant up liberty_to_newton
-  config.vm.define "liberty_to_newton" do |liberty_to_newton|
-    liberty_to_newton.vm.box = "ubuntu/trusty64"
-    liberty_to_newton.disksize.size = disk_size
-    liberty_to_newton.vm.hostname = "liberty"
-    config.vm.provision "shell",
-      privileged: true,
-      inline: <<-SHELL
-          sudo su -
-          apt update
-          apt-get -y install git build-essential gcc libssl-dev libffi-dev python-dev
-          git clone https://github.com/rcbops/rpc-upgrades.git /opt/rpc-upgrades
-          cd /opt/rpc-upgrades
-          RE_JOB_SERIES=liberty ./run-tests.sh
-      SHELL
-  end
+  # Configure cache options
+  config.cache.scope = :box
 
-  ### vagrant up r12.2.8_to_newton
-  config.vm.define "r12_2_8_to_newton" do |r12_2_8_to_newton|
-    r12_2_8_to_newton.vm.box = "ubuntu/trusty64"
-    r12_2_8_to_newton.disksize.size = disk_size
-    r12_2_8_to_newton.vm.hostname = "r12.2.8"
-    config.vm.provision "shell",
-      privileged: true,
-      inline: <<-SHELL
-          sudo su -
-          apt update
-          apt-get -y install git build-essential gcc libssl-dev libffi-dev python-dev
-          git clone https://github.com/rcbops/rpc-upgrades.git /opt/rpc-upgrades
-          cd /opt/rpc-upgrades
-          RE_JOB_SERIES=liberty RE_JOB_CONTEXT=r12.2.8 ./run-tests.sh
-      SHELL
-  end
+  ### vagrant up job actions
+  job_actions.each do |job_action|
+    (upgrade_from, _, upgrade_to, upgrade_type) = job_action.split("_")
 
-  ### vagrant up kilo_to_newton
-  config.vm.define "kilo_to_newton" do |kilo_to_newton|
-    kilo_to_newton.vm.box = "ubuntu/trusty64"
-    kilo_to_newton.disksize.size = disk_size
-    kilo_to_newton.vm.hostname = "kilo"
-    config.vm.provision "shell",
-      privileged: true,
-      inline: <<-SHELL
-          sudo su -
-          apt update
-          apt-get -y install git build-essential gcc libssl-dev libffi-dev python-dev
-          git clone https://github.com/rcbops/rpc-upgrades.git /opt/rpc-upgrades
-          cd /opt/rpc-upgrades
-          RE_JOB_SERIES=kilo ./run-tests.sh
-      SHELL
+    config.vm.define job_action do |job|
+      job.vm.hostname = upgrade_from.gsub(".", "-")
+      job.vm.provision "shell",
+        privileged: true,
+        inline: <<-SHELL
+            sudo su -
+            apt update
+            apt-get -y install git build-essential gcc libssl-dev libffi-dev python-dev
+            ln -s /vagrant /opt/rpc-upgrades
+            pushd /opt/rpc-upgrades
+            export RE_JOB_ACTION="#{job_action}"
+            ./run-tests.sh
+        SHELL
+    end
   end
 
 end

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -15,44 +15,7 @@
 
 set -xeuo pipefail
 
-echo "Gate job started"
-echo "+-------------------- START ENV VARS --------------------+"
-env
-echo "+-------------------- START ENV VARS --------------------+"
+export RE_JOB_ACTION="${RE_JOB_ACTION:-liberty_to_newton_leap}"
 
-export FUNCTIONAL_TEST=${FUNCTIONAL_TEST:-true}
-
-# Install python2 for Ubuntu 16.04 and CentOS 7
-if which apt-get; then
-    sudo apt-get update && sudo apt-get install -y python wget
-fi
-
-if which yum; then
-    sudo yum install -y python wget
-fi
-
-# Install pip.
-if ! which pip; then
-  curl --silent --show-error --retry 5 \
-    https://bootstrap.pypa.io/get-pip.py | sudo python2.7
-fi
-
-# Install bindep and tox with pip.
-sudo pip install bindep tox
-
-# CentOS 7 requires two additional packages:
-#   redhat-lsb-core - for bindep profile support
-#   epel-release    - required to install python-ndg_httpsclient/python2-pyasn1
-if which yum; then
-    sudo yum -y install redhat-lsb-core epel-release
-fi
-
-if [ "${FUNCTIONAL_TEST}" = true ]; then
-  sudo -H --preserve-env ./run-bindep.sh
-  sudo -H --preserve-env pip install -r test-requirements.txt
-  sudo -H --preserve-env ./tests/aio-create.sh
-  sudo -H --preserve-env ./tests/test-upgrade.sh
-#  sudo -H --preserve-env ./tests/run-tempest.sh
-else
-  sudo -H --preserve-env tox
-fi
+sudo -H --preserve-env ./gating/pre_merge_test/pre
+sudo -H --preserve-env ./gating/pre_merge_test/run

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,0 @@
-run-tests.sh

--- a/testing.rst
+++ b/testing.rst
@@ -10,26 +10,26 @@ The flavor ID: 7 (15GB Standard Instance) works well using the
 `Ubuntu 14.04 LTS (Trusty Tahr) (PVHVM)` image.
 
 Once the test VM is online, simply clone this repo, checkout your
-desired branch, set the RE_JOB_CONTEXT and run the script
-`run-tests.sh`.
+desired branch, set the RE_JOB_ACTION and run the script
+`run-tests.sh`. This will perform the upgrade exactly as gating
+job hooks will.
 
 .. code-block:: shell
 
-    RE_JOB_SERIES=kilo ./run-tests.sh
+    RE_JOB_ACTION=<from_version>_to_<to_version>_<upgrade_action>
+    RE_JOB_ACTION=kilo_to_newton_leap ./run-tests.sh
 
 
-If you wish to run the tests against a specific checkout within a
-given context set the variable `RE_JOB_SERIES` to the checkout you
-wish to test with.
+If you wish to run the tests against a specific version, set the
+from and to versions in `RE_JOB_ACTION` to the versions or branches
+you wish to test with.
 
 .. code-block:: shell
 
-    # Build the environment using the kilo context
-    #  Use RPC-O version r11.1.1 to create our AIO.
-    RE_JOB_CONTEXT=r11.1.1 RE_JOB_SERIES=kilo ./run-tests.sh
+    RE_JOB_ACTION=r11.1.8_to_r14.4.1_leap ./run-tests.sh
 
 
 When you executing the `run-tests.sh` script a full AIO will be
-built and then the leapfrog tools executed against it. This will
+built and then the upgrade tools executed against it. This will
 allow for the rapid testing and proto-typing within a localized
 environment.


### PR DESCRIPTION
* Removed old run_tests.sh symlink
* Updated run-tests.sh to call ./gating/pre_merge_test/pre and run
* Updated Vagrantfile with new RE_JOB_ACTION syntax and matrix