### PR TITLE
RLM-511 Bump to latest OSA_OPS branch

### DIFF
--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -39,7 +39,7 @@ export OA_OPS_REPO=${OA_OPS_REPO:-'https://github.com/openstack/openstack-ansibl
 # Please bump the following when a patch for leapfrog is merged into osa-ops
 # If you are developping, just clone your ops repo into (by default)
 # /opc/rpc-leapfrog/openstack-ansible-ops
-export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'aa050307aab3a044c7875c1e7f00368ccda812aa'}
+export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'0421a02e0c7d37af2b5fb145e8723dc04aba4a87'}
 # Instead of storing the debug's log of run in /tmp, we store it in an
 # folder that will get archived for gating logs
 export REDEPLOY_OA_FOLDER="${RPCO_DEFAULT_FOLDER}/openstack-ansible"


### PR DESCRIPTION
Existing SHA seemed to go AWOL (https://github.com/openstack/openstack-ansible-ops/commit/aa050307aab3a044c7875c1e7f00368ccda812aa) so bumping to latest.