### PR TITLE
RLM-526 Run from a directory with an ansible.cfg

### DIFF
--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -34,7 +34,7 @@ sudo --preserve-env $(readlink -e $(dirname ${0}))/../scripts/ubuntu14-leapfrog.
 
 # if rpc-maas repo exists, run maas-verify
 if [ -d "/opt/rpc-maas" ]; then
-  pushd /opt/rpc-maas/playbooks
-    openstack-ansible maas-verify.yml -vv
+  pushd /opt/rpc-upgrades/playbooks
+    openstack-ansible /opt/rpc-maas/playbooks/maas-verify.yml -vv
   popd
 fi


### PR DESCRIPTION
The last commit probably won't work as there's no ansible.cfg in that directory which prevents the inventory from being loaded.  This should allow for it to find it.