### PR TITLE
RLM-554 Various MaaS fixes

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -66,6 +66,7 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   fi
   sudo -H --preserve-env ./tests/maas-install.sh
   sudo -H --preserve-env ./tests/test-upgrade.sh
+  sudo -H --preserve-env ./tests/maas-install.sh
 #  sudo -H --preserve-env ./tests/run-tempest.sh
 else
   sudo -H --preserve-env tox

--- a/playbooks/remove-old-agents-from-maas.yml
+++ b/playbooks/remove-old-agents-from-maas.yml
@@ -13,5 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- include: "../playbooks/generate-resources.yml"
-- include: "../playbooks/remove-old-agents-from-maas.yml"
+- hosts: hosts
+  gather_facts: no
+  tasks:
+    - name: Get list of old containers
+      command: "cat /etc/openstack_deploy/leapfrog_remove_remaining_old_containers"
+      run_once: true
+      delegate_to: localhost
+      register: old_containers
+      tags:
+        - skip_ansible_lint
+
+    - name: Remove old MaaS neutron container config files
+      shell: "rm /etc/rackspace-monitoring-agent.conf.d/*{{ item }}*"
+      with_items: "{{ old_containers.stdout_lines }}"
+      ignore_errors: true
+      tags:
+        - skip_ansible_lint

--- a/scripts/post_leap.sh
+++ b/scripts/post_leap.sh
@@ -28,6 +28,7 @@ if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/deploy-rpc.complete" ]]; then
     sed -i 's#\*"/opt/openstack-ansible"\*#\*"/opt/rpc-openstack/openstack-ansible"\*#' /usr/local/bin/ansible
     # TODO(remove the following hack to restart the neutron agents, when fixed upstream)
     ansible -m shell -a "restart neutron-linuxbridge-agent" nova_compute -i /opt/rpc-openstack/openstack-ansible/playbooks/inventory/dynamic_inventory.py
+    openstack-ansible ${RPC_UPGRADES_DEFAULT_FOLDER}/playbooks/remove-old-agents-from-maas.yml
     . ${RPCO_DEFAULT_FOLDER}/scripts/deploy-rpc-playbooks.sh
   popd
   log "deploy-rpc" "ok"

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -95,7 +95,6 @@ function set_gating_vars {
 neutron_legacy_ha_tool_enabled: true
 lxc_container_backing_store: dir
 maas_use_api: false
-maas_release: master
 EOF
 }
 

--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -22,14 +22,12 @@ export RPC_TARGET_CHECKOUT=${RE_JOB_UPGRADE_TO:-'newton'}
 
 if [ "${RE_JOB_SERIES}" == "kilo" ]; then
   export OA_OPS_REPO_BRANCH="50f3fd6df7579006748a00c271bb03d22b17ae89"
+  export UPGRADE_ELASTICSEARCH=no
+  export CONTAINERS_TO_DESTROY='all_containers:!galera_all:!neutron_agent:!ceph_all:!rsyslog_all'
+elif [ "${RE_JOB_SERIES}" == "liberty" ]; then
+  export UPGRADE_ELASTICSEARCH=no
+  export CONTAINERS_TO_DESTROY='all_containers:!galera_all:!neutron_agent:!ceph_all:!rsyslog_all'
 fi
 
 # execute leapfrog
 sudo --preserve-env $(readlink -e $(dirname ${0}))/../scripts/ubuntu14-leapfrog.sh
-
-# if rpc-maas repo exists, run maas-verify
-#if [ -d "/opt/rpc-maas" ]; then
-#  pushd /opt/rpc-upgrades/playbooks
-#    openstack-ansible /opt/rpc-maas/playbooks/maas-verify.yml -vv
-#  popd
-#fi


### PR DESCRIPTION
Restores playbook to remove old neutron container maas entries
which was removed in RLM-416.

Runs maas-install before and after leapfrog which gets rpc-maas
if it's not present, installs, and verifies.  It also handles
the jumping around of the maas_release variable and sets it to
master by default for now.

Also disables the Elastic Search Upgrade jobs on Kilo and Liberty.  The job currently works on L->N but not L-N-14.5 because the required rpc-o commit won't be in the release until 14.6.0.  It also is not currently supported on Kilo.  Leaving them disabled for now and we can reenable once 14.6.0 drops.