### PR TITLE
Use latest OA_OPS for ES and don't run on Kilo

### DIFF
--- a/playbooks/elasticsearch-reindex.yml
+++ b/playbooks/elasticsearch-reindex.yml
@@ -30,13 +30,17 @@
         pattern: logstash
 
 - name: New session to reindex Elasticsearch
-  command: "{{ item }}"
-  args:
-    chdir: /opt/rpc-openstack/rpcd/playbooks
-  with_items:
-    - tmux new-session -d -s es-reindex
-    - tmux select-pane -t es-reindex
-    - tmux send-keys "openstack-ansible -e 'logging_upgrade=true' --tags 'reindex-wrapper,elasticsearch-upgrade' elasticsearch.yml" C-m
+  hosts: localhost
+  user: root
+  tasks:
+    - name: Session to reindex Elasticsearch
+      command: "{{ item }}"
+      args:
+        chdir: /opt/rpc-openstack/rpcd/playbooks
+      with_items:
+        - tmux new-session -d -s es-reindex
+        - tmux select-pane -t es-reindex
+        - tmux send-keys "openstack-ansible -e 'logging_upgrade=true' --tags 'reindex-wrapper,elasticsearch-upgrade' elasticsearch.yml" C-m
 
 - name: Start logstash serivce
   hosts: logstash_all

--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -231,6 +231,8 @@ pushd /opt/rpc-openstack
     #                  Sadly this takes forever and is largely broken. This
     #                  changes the default behaviour to build.
     echo -e "---\n- include: repo-server.yml\n- include: repo-build.yml" | tee ${OSA_PATH}/playbooks/repo-install.yml
+    # don't attempt an elasticsearch upgrade on kilo
+    export UPGRADE_ELASTICSEARCH="no"
   elif [ "${RE_JOB_SERIES}" == "liberty" ]; then
     git_checkout "liberty"  # Last commit of Liberty
     (git submodule init && git submodule update) || true

--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -18,18 +18,13 @@ set -evu
 
 export VALIDATE_UPGRADE_INPUT=false
 export AUTOMATIC_VAR_MIGRATE_FLAG="--for-testing-take-new-vars-only"
+export RPC_TARGET_CHECKOUT=${RE_JOB_UPGRADE_TO:-'newton'}
 
 if [ "${RE_JOB_SERIES}" == "kilo" ]; then
-  export RPC_TARGET_CHECKOUT="r14.2.0"
   export OA_OPS_REPO_BRANCH="50f3fd6df7579006748a00c271bb03d22b17ae89"
-elif [ "${RE_JOB_SERIES}" == "liberty" ]; then
-  export RPC_TARGET_CHECKOUT="newton"
-  export OA_OPS_REPO_BRANCH="0690bb608527b90596e5522cc852ffa655228807"
-elif [ "${RE_JOB_SERIES}" == "mitaka" ]; then
-  export RPC_TARGET_CHECKOUT="newton"
-  export OA_OPS_REPO_BRANCH="0690bb608527b90596e5522cc852ffa655228807"
 fi
 
+# execute leapfrog
 sudo --preserve-env $(readlink -e $(dirname ${0}))/../scripts/ubuntu14-leapfrog.sh
 
 # if rpc-maas repo exists, run maas-verify


### PR DESCRIPTION
Uses the latest OA_OPS to pull in the containers_to_destroy work, doesn't upgrade ES on kilo, and fixes a playbook syntax issue in the reindex playbook.