### PR TITLE
Prevent modules from getting pulled on first checkout

### DIFF
--- a/tests/aio-create.sh
+++ b/tests/aio-create.sh
@@ -204,7 +204,7 @@ fi
 mkdir -p "${ANSIBLE_LOG_DIR}"
 
 if [ ! -d "/opt/rpc-openstack" ]; then
-  git clone --recursive https://github.com/rcbops/rpc-openstack /opt/rpc-openstack
+  git clone https://github.com/rcbops/rpc-openstack /opt/rpc-openstack
 else
   pushd /opt/rpc-openstack
     git fetch --all


### PR DESCRIPTION
By pulling recursive on the first run, it pulls all submodules (artifacts) and causes issues on checkouts of the branches.  Removes the recursive and updates submodules once the branch is changed.