### PR TITLE
RLM-307 Add QC test in post-leap

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -66,6 +66,7 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   fi
   sudo -H --preserve-env ./tests/maas-install.sh
   sudo -H --preserve-env ./tests/test-upgrade.sh
+  sudo -H --preserve-env ./tests/qc-test.sh
 #  sudo -H --preserve-env ./tests/run-tempest.sh
 else
   sudo -H --preserve-env tox

--- a/playbooks/qc-post-leap.yml
+++ b/playbooks/qc-post-leap.yml
@@ -1,0 +1,22 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Quality checking after leaping
+  hosts: "hosts:all_containers"
+  gather_facts: false
+  user: root
+  tasks:
+    - name: Ping check
+      ping:

--- a/scripts/post_leap.sh
+++ b/scripts/post_leap.sh
@@ -35,6 +35,10 @@ else
   log "deploy-rpc" "skipped"
 fi
 
+if [ "QC_TEST" == "yes" ]; then
+  . /opt/rpc-upgrades/tests/qc-test.sh
+fi
+
 if [ "$UPGRADE_ELASTICSEARCH" == "yes" ]; then
   pushd /opt/rpc-upgrades/playbooks
     openstack-ansible elasticsearch-reindex.yml

--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -52,6 +52,7 @@ export RPCD_DEFAULTS='/etc/openstack_deploy/user_rpco_variables_defaults.yml'
 export OA_DEFAULTS='/etc/openstack_deploy/user_osa_variables_defaults.yml'
 # Set the target checkout used when leaping forward.
 export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'r14.2.0'}
+export QC_TEST=${QC_TEST:-'no'}
 
 ### Functions -----------------------------------------------------------------
 function log {

--- a/tests/qc-test.sh
+++ b/tests/qc-test.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -evu
+
+## Quality checking
+pushd /opt/rpc-upgrades/playbooks
+  openstack-ansible qc-post-leap.yml
+popd


### PR DESCRIPTION
Create a post upgrade playbook to run support QC steps after the upgrade is
complete. This might be run automatically in the gates, but manually in 
customer upgrades.