### PR TITLE
RLM-842 Use mirror.rackspace.com for MNAIO

### DIFF
--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -49,6 +49,8 @@ export DATA_DISK_DEVICE="sdb"
 export CONFIG_PREROUTING="false"
 export OSA_PORTS="6080 6082 443 80 8443"
 export RPC_BRANCH="${RE_JOB_CONTEXT}"
+export DEFAULT_MIRROR_HOSTNAME=mirror.rackspace.com
+export DEFAULT_MIRROR_DIR=/ubuntu
 
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"


### PR DESCRIPTION
Uses mirror.rackspace.com instead of archive.ubuntu.com due to reliability issues.  Dependent on https://review.openstack.org/#/c/527802/.