### PR TITLE
RLM-900 Set the terminal before running Leapfrog

### DIFF
--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -119,8 +119,7 @@ EOF
 
 # split out to capture exit codes if scripts fail
 # start the rpc-o install from infra1
-${MNAIO_SSH} "export TERM=linux; \
-              source /opt/rpc-upgrades/RE_ENV; \
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
               source /opt/rpc-upgrades/tests/ansible-env.rc; \
               pushd /opt/rpc-openstack; \
               export DEPLOY_ELK=yes; \
@@ -144,32 +143,28 @@ ${MNAIO_SSH} "export TERM=linux; \
 echo "MNAIO RPC-O deploy completed..."
 
 # Install and Verify MaaS post deploy
-#${MNAIO_SSH} "export TERM=linux; \
-#              source /opt/rpc-upgrades/RE_ENV; \
+#${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
 #              source /opt/rpc-upgrades/tests/ansible-env.rc; \
 #              pushd /opt/rpc-upgrades; \
 #              tests/maas-install.sh"
 #echo "MaaS Install and Verify Post Deploy completed..."
 
 # Run Leapfrog upgrade
-${MNAIO_SSH} "export TERM=linux; \
-              source /opt/rpc-upgrades/RE_ENV; \
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
               source /opt/rpc-upgrades/tests/ansible-env.rc; \
               pushd /opt/rpc-upgrades; \
               tests/test-upgrade.sh"
 echo "Leapfrog completed..."
 
 # Install and Verify MaaS post leapfrog
-#${MNAIO_SSH} "export TERM=linux; \
-#              source /opt/rpc-upgrades/RE_ENV; \
+#${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
 #              source /opt/rpc-upgrades/tests/ansible-env.rc; \
 #              pushd /opt/rpc-upgrades; \
 #              tests/maas-install.sh"
 #echo "MaaS Install and Verify Post Leapfrog completed..."
 
 # Run final QC Tests
-${MNAIO_SSH} "export TERM=linux; \
-              source /opt/rpc-upgrades/RE_ENV; \
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
               source /opt/rpc-upgrades/tests/ansible-env.rc; \
               pushd /opt/rpc-upgrades; \
               tests/qc-test.sh"

--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -29,5 +29,8 @@ elif [ "${RE_JOB_SERIES}" == "liberty" ]; then
   export CONTAINERS_TO_DESTROY='all_containers:!galera_all:!neutron_agent:!ceph_all:!rsyslog_all'
 fi
 
+# export the term to avoid unknown: I need something more specific error in jenkins
+export TERM=linux
+
 # execute leapfrog
 sudo --preserve-env $(readlink -e $(dirname ${0}))/../scripts/ubuntu14-leapfrog.sh


### PR DESCRIPTION
Jenkins doesn't seem to be happy if the term is not set and tosses
a 'unknown': I need something more specific. when running leapfrog.

This attempts to get around that issue.