### PR TITLE
RLM-899 Ensure ansible retries are getting ran for AIO and MNAIO

### DIFF
--- a/tests/create-aio.sh
+++ b/tests/create-aio.sh
@@ -35,6 +35,15 @@ if [ ! -d "/opt/rpc-openstack" ]; then
   popd
 fi
 
+# RLM-434 Implement ansible retries for mitaka and below
+case "${RE_JOB_SERIES}" in
+  kilo|liberty|mitaka)
+    export ANSIBLE_SSH_RETRIES=10
+    export ANSIBLE_GIT_RELEASE=ssh_retry
+    export ANSIBLE_GIT_REPO=https://github.com/hughsaunders/ansible
+    ;;
+esac
+
 pushd /opt/rpc-openstack
   export DEPLOY_HAPROXY="yes"
   export DEPLOY_MAAS="no"

--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -101,6 +101,16 @@ pushd /opt/openstack-ansible-ops/multi-node-aio
 popd
 echo "Multi Node AIO setup completed..."
 
+# RLM-434 Implement ansible retries for mitaka and below
+# Copies into RE_ENV which will be sourced when deploy is ran
+case "${RE_JOB_SERIES}" in
+  kilo|liberty|mitaka)
+    echo "export ANSIBLE_SSH_RETRIES=10" >> /opt/rpc-upgrades/RE_ENV
+    echo "export ANSIBLE_GIT_RELEASE=ssh_retry" >> /opt/rpc-upgrades/RE_ENV
+    echo "export ANSIBLE_GIT_REPO=https://github.com/hughsaunders/ansible" >> /opt/rpc-upgrades/RE_ENV
+    ;;
+esac
+
 # prepare rpc-o configs
 set -xe
 scp -r -o StrictHostKeyChecking=no /opt/rpc-openstack infra1:/opt/
@@ -136,9 +146,6 @@ ${MNAIO_SSH} "export TERM=linux; \
               export DEPLOY_SWIFT=yes; \
               export DEPLOY_RPC=yes; \
               export ANSIBLE_FORCE_COLOR=true; \
-              export ANSIBLE_SSH_RETRIES=10; \
-              export ANSIBLE_GIT_RELEASE=ssh_retry; \
-              export ANSIBLE_GIT_REPO=https://github.com/hughsaunders/ansible; \
               scripts/deploy.sh"
 
 echo "MNAIO RPC-O deploy completed..."

--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -170,13 +170,6 @@ function maas_tweaks {
   fi
 }
 
-function ansible_retry {
-  # RLM-434 Implement ansible retries for mitaka and below
-  export ANSIBLE_SSH_RETRIES=3
-  export ANSIBLE_GIT_RELEASE=ssh_retry
-  export ANSIBLE_GIT_REPO=https://github.com/hughsaunders/ansible
-}
-
 ## Main ----------------------------------------------------------------------
 echo "Gate test starting
 with:
@@ -215,7 +208,6 @@ pushd /opt/rpc-openstack
     kilo_caches
     allow_frontloading_vars
     get_ssh_role
-    ansible_retry
 
     # NOTE(cloudnull): Pycrypto has to be limited.
     sed -i 's|pycrypto.*|pycrypto<=2.6.1|g' ${OSA_PATH}/requirements.txt
@@ -238,7 +230,6 @@ pushd /opt/rpc-openstack
     get_ssh_role
     fix_galera_apt_cache
     maas_tweaks
-    ansible_retry
     # NOTE(cloudnull): The global requirement pins for early Liberty are broken.
     #                  This pull the pins forward so that we can continue with
     #                  the AIO deployment for liberty
@@ -252,7 +243,6 @@ pushd /opt/rpc-openstack
     pin_galera "10.0"
     unset_affinity
     allow_frontloading_vars
-    ansible_retry
   elif [ "${RE_JOB_SERIES}" == "newton" ]; then
     git_checkout "newton"  # Last commit of Newton
     (git submodule init && git submodule update) || true


### PR DESCRIPTION
Previously retries for AIO was not getting sourced any more
since breaking out prepare-rpco and create-aio.  This should
handle it better and cleans up the code a bit.