### PR TITLE
Verify MaaS only after leapfrog

### DIFF
--- a/tests/maas-install.sh
+++ b/tests/maas-install.sh
@@ -41,6 +41,8 @@ pushd /opt/rpc-upgrades/playbooks
    openstack-ansible /opt/rpc-maas/playbooks/site.yml -vv
   fi
 
-  # verify rpc-maas
-  openstack-ansible /opt/rpc-maas/playbooks/maas-verify.yml -vv
+  # verify rpc-maas if leap has completed
+  if [[ -f /etc/openstack_deploy/upgrade-leap/osa-leap.complete ]]; then
+    openstack-ansible /opt/rpc-maas/playbooks/maas-verify.yml -vv
+  fi
 popd


### PR DESCRIPTION
Running verify after initial deploy in gating is redundant
and doesn't really buy us much if we're proceeding
with a leapfrog anyways and retesting afterwards.