### PR TITLE
RLM-1043 Update target version to r14.6.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Overview
 A Leapfrog upgrade is a major upgrade that skips at least one release. Currently
 rpc-upgrades repo supports supports leapfrog upgrades from:
 
-* liberty to r14.5.0 (newton)
+* liberty to r14.6.0 (newton)
 
 If you are looking for the Kilo to 14.2.0 (newton) support, it exists directly in the
 `RPC-O <https://github.com/rcbops/rpc-openstack/tree/r14.2.0/scripts/leapfrog>`_ repo.  
@@ -24,7 +24,7 @@ Terms
 * `OSA <https://github.com/openstack/openstack-ansible>`_:  OpenStack Ansible
 * `OSA-OPS <https://github.com/openstack/openstack-ansible-ops>`_:  OpenStack Operations
 * `Liberty <https://github.com/rcbops/rpc-openstack/tree/liberty>`_: The RPCO release of OpenStack Liberty
-* `r14.5.0 <https://github.com/rcbops/rpc-openstack/tree/r14.5.0>`_: The fifth RPCO release of OpenStack Newton.
+* `r14.6.0 <https://github.com/rcbops/rpc-openstack/tree/r14.6.0>`_: The sixth RPCO release of OpenStack Newton.
 
 Pre Leapfrog Tasks
 ------------------
@@ -69,7 +69,7 @@ The next step is to execute the leapfrog upgrade script and follow the prompts:
     cd /opt/rpc-upgrades
     scripts/ubuntu14-leapfrog.sh
 
-**Note:** *Currently the rpc-upgrades repo targets r14.5.0.*
+**Note:** *Currently the rpc-upgrades repo targets r14.6.0.*
 
 Structure of the leapfrog process
 ---------------------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,11 +18,12 @@ end
 job_actions = [
   "kilo_to_newton_leap",
   "kilo_to_r14.2.0_leap",
+  "kilo_to_r14.6.0_leap",
   "liberty_to_newton_leap",
-  "r12.2.8_to_r14.5.0_leap",
-  "r12.1.2_to_r14.5.0_leap",
-  "r12.2.2_to_r14.5.0_leap",
-  "r12.2.5_to_r14.5.0_leap",
+  "r12.1.2_to_r14.6.0_leap",
+  "r12.2.2_to_r14.6.0_leap",
+  "r12.2.5_to_r14.6.0_leap",
+  "r12.2.8_to_r14.6.0_leap",
 ]
 
 Vagrant.configure("2") do |config|

--- a/gating/README.md
+++ b/gating/README.md
@@ -36,6 +36,6 @@ We use multiple variables in the action variable to determine what type of job w
 
      "release-version-deployed_to_target-release_action"
 
-so "r12.2.5_to_r14.4.1_leap" would mean, deploy r12.2.5 of rpc-openstack, and then leap to r14.4.1.  If you need to change the target release version to be tested, you would modify the second release value in the action.
+so "r12.2.8_to_r14.6.0_leap" would mean, deploy r12.2.8 of rpc-openstack, and then leap to r14.6.0.  If you need to change the target release version to be tested, you would modify the second release value in the action.
 
 Image is used to define whether the job is an AIO (All-in-One) job or a MNAIO (Multi Node AIO) job.

--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -51,7 +51,7 @@ export POST_LEAP_STEPS="${LEAP_BASE_DIR}/post_leap.sh"
 export RPCD_DEFAULTS='/etc/openstack_deploy/user_rpco_variables_defaults.yml'
 export OA_DEFAULTS='/etc/openstack_deploy/user_osa_variables_defaults.yml'
 # Set the target checkout used when leaping forward.
-export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'r14.5.0'}
+export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'r14.6.0'}
 export QC_TEST=${QC_TEST:-'no'}
 
 ### Functions -----------------------------------------------------------------

--- a/testing.rst
+++ b/testing.rst
@@ -26,7 +26,7 @@ you wish to test with.
 
 .. code-block:: shell
 
-    RE_JOB_ACTION=r11.1.8_to_r14.4.1_leap ./run-tests.sh
+    RE_JOB_ACTION=r12.2.8_to_r14.6.0_leap ./run-tests.sh
 
 
 When you executing the `run-tests.sh` script a full AIO will be


### PR DESCRIPTION
Now that r14.6.0 has been released and changed in the gate jobs, all
examples and the default version have been updated to r14.6.0