### PR TITLE
Adds a flag for skipping UPGRADES, default is yes

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -39,6 +39,7 @@ export ANSIBLE_LOG_DIR="${TESTING_HOME}/.ansible/logs"
 export ANSIBLE_LOG_PATH="${ANSIBLE_LOG_DIR}/ansible-aio.log"
 export OSA_PATH="/opt/rpc-openstack/openstack-ansible"
 export WORKSPACE_PATH=`pwd`
+export RUN_UPGRADES="${RUN_UPGRADES:-yes}"
 
 ## Main ----------------------------------------------------------------------
 
@@ -68,15 +69,17 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   else
     sudo -H --preserve-env ./tests/create-aio.sh
     sudo -H --preserve-env ./tests/maas-install.sh
-    sudo -H --preserve-env ./tests/test-upgrade.sh
-    sudo -H --preserve-env ./tests/maas-install.sh
-    sudo -H --preserve-env ./tests/qc-test.sh
-    # RLM-292 secondary test-upgrade run to validate idempotency
-    export RUN_PREFLIGHT=no
-    sudo -H --preserve-env ./tests/test-upgrade.sh
-    # RLM-293 secondary qc run after test-upgrade attempt
-    sudo -H --preserve-env ./tests/qc-test.sh
-    #sudo -H --preserve-env ./tests/run-tempest.sh
+    if [[ "$RUN_UPGRADES" == "yes" ]]; then
+      sudo -H --preserve-env ./tests/test-upgrade.sh
+      sudo -H --preserve-env ./tests/maas-install.sh
+      sudo -H --preserve-env ./tests/qc-test.sh
+      # RLM-292 secondary test-upgrade run to validate idempotency
+      export RUN_PREFLIGHT=no
+      sudo -H --preserve-env ./tests/test-upgrade.sh
+      # RLM-293 secondary qc run after test-upgrade attempt
+      sudo -H --preserve-env ./tests/qc-test.sh
+      #sudo -H --preserve-env ./tests/run-tempest.sh
+    fi
   fi
 else
   sudo -H --preserve-env tox

--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -54,6 +54,7 @@ export DEFAULT_MIRROR_DIR=/ubuntu
 
 # ssh command used to execute tests on infra1
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
+export RUN_UPGRADES="${RUN_UPGRADES:-yes}"
 
 #export ADDITIONAL_COMPUTE_NODES=${env.ADDITIONAL_COMPUTE_NODES}
 #export ADDITIONAL_VOLUME_NODES=${env.ADDITIONAL_VOLUME_NODES}
@@ -158,23 +159,26 @@ ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
               tests/maas-install.sh"
 echo "MaaS Install and Verify Post Deploy completed..."
 
-# Run Leapfrog upgrade
-${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
-              source /opt/rpc-upgrades/tests/ansible-env.rc; \
-              pushd /opt/rpc-upgrades; \
-              tests/test-upgrade.sh"
-echo "Leapfrog completed..."
+if [[ "$RUN_UPGRADES" == "yes" ]]; then
+  # Run Leapfrog upgrade
+  ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+                source /opt/rpc-upgrades/tests/ansible-env.rc; \
+                pushd /opt/rpc-upgrades; \
+                tests/test-upgrade.sh"
+  echo "Leapfrog completed..."
 
-# Install and Verify MaaS post leapfrog
-${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
-              source /opt/rpc-upgrades/tests/ansible-env.rc; \
-              pushd /opt/rpc-upgrades; \
-              tests/maas-install.sh"
-echo "MaaS Install and Verify Post Leapfrog completed..."
+  # Install and Verify MaaS post leapfrog
+  ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+                source /opt/rpc-upgrades/tests/ansible-env.rc; \
+                pushd /opt/rpc-upgrades; \
+                tests/maas-install.sh"
+  echo "MaaS Install and Verify Post Leapfrog completed..."
 
-# Run final QC Tests
-${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
-              source /opt/rpc-upgrades/tests/ansible-env.rc; \
-              pushd /opt/rpc-upgrades; \
-              tests/qc-test.sh"
-echo "QC Tests completed..."
+  # Run final QC Tests
+  ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+                source /opt/rpc-upgrades/tests/ansible-env.rc; \
+                pushd /opt/rpc-upgrades; \
+                tests/qc-test.sh"
+  echo "QC Tests completed..."
+fi
+


### PR DESCRIPTION
Adds a flag for skipping upgrades in the event a tester wants to do the first part of the deploy but hold off on the remaining steps.