### PR TITLE
[RLM-712] Clean glance cache before leap

### DIFF
--- a/playbooks/glance-cache-cleanup.yml
+++ b/playbooks/glance-cache-cleanup.yml
@@ -43,10 +43,10 @@
       service:
         name: glance-registry
         state: started
-        patter: glance-registry
+        pattern: glance-registry
 
     - name: Restore glance-api
       service:
         name: glance-api
         state: started
-        patter: glance-api
+        pattern: glance-api

--- a/playbooks/glance-cache-cleanup.yml
+++ b/playbooks/glance-cache-cleanup.yml
@@ -1,0 +1,52 @@
+---
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Stop glance services
+  hosts: glance_all
+  user: root
+  tasks:
+    - name: Stop glance-api
+      service:
+        name: glance-api
+        state: stopped
+        pattern: glance-api
+
+    - name: Stop glance-registry
+      service:
+        name: glance-registry
+        state: stopped
+        pattern: glance-registry
+
+    - name: Wipe glance cache directory
+      file:
+        state: absent
+        path: "/var/lib/glance/cache/"
+
+    - name: Generate cache directory
+      file:
+        state: directory
+        path: "/var/lib/glance/cache/"
+
+    - name: Restore glance-api
+      service:
+        name: glance-api
+        state: started
+        patter: glance-api
+
+    - name: Restore glance-registry
+      service:
+        name: glance-registry
+        state: started
+        patter: glance-registry

--- a/playbooks/glance-cache-cleanup.yml
+++ b/playbooks/glance-cache-cleanup.yml
@@ -39,14 +39,14 @@
         state: directory
         path: "/var/lib/glance/cache/"
 
-    - name: Restore glance-api
-      service:
-        name: glance-api
-        state: started
-        patter: glance-api
-
     - name: Restore glance-registry
       service:
         name: glance-registry
         state: started
         patter: glance-registry
+
+    - name: Restore glance-api
+      service:
+        name: glance-api
+        state: started
+        patter: glance-api

--- a/scripts/pre_leap.sh
+++ b/scripts/pre_leap.sh
@@ -44,3 +44,8 @@ fi
 
 # RLM-682 versions past 2.5.2 break things
 echo "python-ldap==2.5.2" >> /opt/rpc-openstack/openstack-ansible/global-requirement-pins.txt
+
+# Glance cache cleanup
+pushd /opt/rpc-upgrades/playbooks/
+  openstack-ansible glance-cache-cleanup.yml
+popd

--- a/scripts/pre_leap.sh
+++ b/scripts/pre_leap.sh
@@ -19,6 +19,11 @@
 set -e -u
 set -o pipefail
 
+# Glance cache cleanup
+pushd /opt/rpc-upgrades/playbooks/
+  openstack-ansible glance-cache-cleanup.yml
+popd
+
 # Preserve Elasticsearch data in the leap
 export UPGRADE_ELASTICSEARCH=${UPGRADE_ELASTICSEARCH:-"yes"}
 export CONTAINERS_TO_DESTROY=${CONTAINERS_TO_DESTROY:-'all_containers:!galera_all:!neutron_agent:!ceph_all:!rsyslog_all:!elasticsearch_all'}
@@ -44,8 +49,3 @@ fi
 
 # RLM-682 versions past 2.5.2 break things
 echo "python-ldap==2.5.2" >> /opt/rpc-openstack/openstack-ansible/global-requirement-pins.txt
-
-# Glance cache cleanup
-pushd /opt/rpc-upgrades/playbooks/
-  openstack-ansible glance-cache-cleanup.yml
-popd

--- a/scripts/pre_leap.sh
+++ b/scripts/pre_leap.sh
@@ -19,11 +19,6 @@
 set -e -u
 set -o pipefail
 
-# Glance cache cleanup
-pushd /opt/rpc-upgrades/playbooks/
-  openstack-ansible glance-cache-cleanup.yml
-popd
-
 # Preserve Elasticsearch data in the leap
 export UPGRADE_ELASTICSEARCH=${UPGRADE_ELASTICSEARCH:-"yes"}
 export CONTAINERS_TO_DESTROY=${CONTAINERS_TO_DESTROY:-'all_containers:!galera_all:!neutron_agent:!ceph_all:!rsyslog_all:!elasticsearch_all'}

--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -88,7 +88,7 @@ fi
 # Glance cache cleanup
 pushd /opt/rpc-upgrades/playbooks/
     openstack-ansible glance-cache-cleanup.yml
-pop
+popd
 
 # Let's go
 pushd ${LEAPFROG_DIR}

--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -80,6 +80,11 @@ if [[ ! -d "${UPGRADE_LEAP_MARKER_FOLDER}" ]]; then
     mkdir -p "${UPGRADE_LEAP_MARKER_FOLDER}"
 fi
 
+# Glance cache cleanup
+pushd /opt/rpc-upgrades/playbooks/
+    openstack-ansible glance-cache-cleanup.yml
+pop
+
 # Let's go
 pushd ${LEAPFROG_DIR}
 


### PR DESCRIPTION
This action will wipe all glance image cache before leaping to prevent
the container too full to achieve upgrading.