### PR TITLE
RLM-1118 Don't fail if rpc-openstack is not present

### DIFF
--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -97,8 +97,12 @@ pushd ${LEAPFROG_DIR}
     # Prepare rpc folder
     if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/rpc-prep.complete" ]]; then
         if [[ ! -d "${LEAPFROG_DIR}/rpc-openstack.pre-newton" ]]; then
-            # Cleanup existing RPC, replace with new RPC
-            mv ${RPCO_DEFAULT_FOLDER} ${LEAPFROG_DIR}/rpc-openstack.pre-newton
+            # if existing RPCO folder exists, back it up
+            if [[ -d ${RPCO_DEFAULT_FOLDER} ]]; then
+                 mv ${RPCO_DEFAULT_FOLDER} ${LEAPFROG_DIR}/rpc-openstack.pre-newton
+            fi
+        fi
+        if [[ ! -d ${RPCO_DEFAULT_FOLDER} ]]; then
             git clone -b "${RPC_TARGET_CHECKOUT}" --recursive https://github.com/rcbops/rpc-openstack ${RPCO_DEFAULT_FOLDER}
             pushd /opt/rpc-openstack
                 git fetch --all


### PR DESCRIPTION
Moves existing rpc-openstack to backup directory if
backup directory doesnt exist.  Checks out rpc-openstack
fresh if not present.  This allows rpc-upgrades to be the
only thing needed to checkout to an enviroment and will
pull the items that are needed.