### PR TITLE
Prevent nesting of es-reindex session

### DIFF
--- a/playbooks/elasticsearch-reindex.yml
+++ b/playbooks/elasticsearch-reindex.yml
@@ -33,14 +33,20 @@
   hosts: localhost
   user: root
   tasks:
+    - name: Check for existing tmux session
+      shell: "tmux list-session |grep es-reindex"
+      changed_when: false
+      failed_when: false
+      register: tmux_session
     - name: Session to reindex Elasticsearch
-      command: "{{ item }}"
+      shell: "TMUX='' {{ item }}"
       args:
         chdir: /opt/rpc-openstack/rpcd/playbooks
       with_items:
         - tmux new-session -d -s es-reindex
         - tmux select-pane -t es-reindex
         - tmux send-keys "openstack-ansible -e 'logging_upgrade=true' --tags 'reindex-wrapper,elasticsearch-upgrade' elasticsearch.yml" C-m
+      when: "{{ tmux_session.rc == 1 }}"
 
 - name: Start logstash serivce
   hosts: logstash_all


### PR DESCRIPTION
TMUX does not allow nesting of sessions when running inside a existing
TMUX process. New es-reindex sessions are force created outside of the
current TMUX in order to prevent nesting.
Additionally a check is added to skip the reindex of Elasticsearch
once a es-reindex session is already present.

Closes-Bug: RLM-1127