### PR TITLE
Adding libev4 for liberty xtrabackup patch

### DIFF
--- a/playbooks/patches/liberty/galera_server/galera_server_apt_repo_defaults.patch
+++ b/playbooks/patches/liberty/galera_server/galera_server_apt_repo_defaults.patch
@@ -1,5 +1,5 @@
 diff --git a/playbooks/roles/galera_server/defaults/main.yml b/playbooks/roles/galera_server/defaults/main.yml
-index 6f84c07..01e3d19 100644
+index 6f84c07..fcf2c7d 100644
 --- a/playbooks/roles/galera_server/defaults/main.yml
 +++ b/playbooks/roles/galera_server/defaults/main.yml
 @@ -75,7 +75,7 @@ galera_gpg_keys:
@@ -22,3 +22,10 @@ index 6f84c07..01e3d19 100644
  galera_package_path: "/opt/{{ galera_package_url | basename }}"
 
  galera_pip_packages:
+@@ -105,6 +105,7 @@ galera_pre_apt_packages:
+   - libgcc1
+   - libgcrypt11
+   - libstdc++6
++  - libev4
+   - python-software-properties
+   - software-properties-common


### PR DESCRIPTION
The new xtrabackup requires libev4 but as we are
downloading and installing xtrabackup via dpkg, dependencies are
not resolved. The pre installation of libev4 before xtrabackup
will fix the missing dependency