### PR TITLE
RLM-1146 Removes BOOTSTRAP_ANSIBLE_FOLDER variable

### DIFF
--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -43,7 +43,6 @@ export OA_OPS_REPO_BRANCH=${OA_OPS_REPO_BRANCH:-'d4dbea93a2dfd264546bdb3bafa5ce9
 # Instead of storing the debug's log of run in /tmp, we store it in an
 # folder that will get archived for gating logs
 export REDEPLOY_OA_FOLDER="${RPCO_DEFAULT_FOLDER}/openstack-ansible"
-export BOOTSTRAP_ANSIBLE_FOLDER="${RPCO_DEFAULT_FOLDER}/openstack-ansible"
 export DEBUG_PATH="/var/log/osa-leapfrog-debug.log"
 export UPGRADE_LEAP_MARKER_FOLDER="/etc/openstack_deploy/upgrade-leap"
 export PRE_LEAP_STEPS="${LEAP_BASE_DIR}/pre_leap.sh"


### PR DESCRIPTION
Assumes linked release in /opt/openstack-ansible is
the directory to bootstrap ansible from.

Since this will be linked to the current release
this should provide the version of Ansible we need to
complete upgrade.