### PR TITLE
Adding insecure flag when necessary

### DIFF
--- a/playbooks/roles/rpc_post_upgrade/defaults/main.yml
+++ b/playbooks/roles/rpc_post_upgrade/defaults/main.yml
@@ -17,7 +17,7 @@ date_stamp: "{{ ansible_date_time.date }}"
 time_stamp: "{{ ansible_date_time.time }}"
 datetime_stamp: "{{ date_stamp }}-{{ time_stamp }}"
 local_home: "{{ lookup('env', 'HOME') }}"
-backup_dir: "{{ local_home }}/rpc13-upgrade-{{ date_stamp }}"
+backup_dir: "{{ ansible_env.BKUPDIR |default(local_home+'/'+'rpc-upgrade-'+date_stamp) }}"
 elasticsearch_http_port: 9200
 swift_venv_tag: "{{ openstack_release }}"
 swift_venv_bin: "/openstack/venvs/swift-{{ swift_venv_tag }}/bin"

--- a/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
+++ b/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-utility.yml
@@ -16,8 +16,8 @@
 # Verify services are up and checking in
 - name: Grab relevant output of openstack compute service list
   shell: |
-    . ~/openrc
-    openstack compute service list -c Binary -c Host -c State -f value
+    . {{ ansible_env.HOME }}/openrc
+    openstack {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} compute service list -c Binary -c Host -c State -f value
   register: openstack_output
   failed_when: "openstack_output.rc != 0"
 
@@ -35,8 +35,8 @@
 
 - name: Grab relevant output of neutron agent-list
   shell: |
-    . ~/openrc
-    neutron agent-list -c agent_type -c host -c alive -f value
+    . {{ ansible_env.HOME }}/openrc
+    neutron {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} agent-list -c agent_type -c host -c alive -f value
   register: neutron_output
   failed_when: "neutron_output.rc != 0"
 
@@ -52,7 +52,8 @@
 
 - name: Grab relevant output of neutron port-list
   shell: |
-    . ~/openrc && neutron port-list -c id -c binding:host_id -c device_owner -c status -f value
+    . {{ ansible_env.HOME }}/openrc
+    neutron {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} port-list -c id -c binding:host_id -c device_owner -c status -f value
   register: neutron_port_output
 
 - name: Warn if any neutron ports are in the build state
@@ -74,8 +75,8 @@
 # with '_' in their hostnames must be disregarded as part of this check.
 - name: Grab relevant output of cinder service-list
   shell: |
-    . ~/openrc
-    cinder service-list | grep -vE 'Status|\+|_' | awk '{print $2, $4, $10}'
+    . {{ ansible_env.HOME }}/openrc
+    cinder {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} service-list | grep -vE 'Status|\+|_' | awk '{print $2, $4, $10}'
   register: cinder_output
   failed_when: "cinder_output.rc != 0"
 
@@ -91,8 +92,8 @@
 
 - name: Grab relevant output of orchestration service list
   shell: |
-    . ~/openrc
-    openstack orchestration service list -c Binary -c host -c status -f value
+    . {{ ansible_env.HOME }}/openrc
+    openstack {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} orchestration service list -c Binary -c host -c status -f value
   register: orchestration_output
   failed_when: "orchestration_output.rc != 0"
 
@@ -109,13 +110,13 @@
 - name: Obtain a list of neutron routers
   shell: |
     . {{ ansible_env.HOME }}/openrc
-    neutron router-list -f value --column id
+    neutron {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} router-list -f value --column id
   register: neutron_routers
 
 - name: Check agent assigned to each neutron router
   shell: |
     . {{ ansible_env.HOME }}/openrc
-    neutron l3-agent-list-hosting-router -f value --column host {{ item }}
+    neutron {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} l3-agent-list-hosting-router -f value --column host {{ item }}
   with_items: "{{ neutron_routers.stdout_lines|default([]) }}"
   register: neutron_routers_agents
 

--- a/playbooks/roles/rpc_pre_upgrade/defaults/main.yml
+++ b/playbooks/roles/rpc_pre_upgrade/defaults/main.yml
@@ -16,7 +16,7 @@
 pre_upgrade_original_playbook_dir: "/opt/rpc-openstack/"
 
 date_stamp: "{{ ansible_date_time.date }}"
-time_stamp: "{{ ansible_date_time.time }}"
+time_stamp: "{{ ansible_date_time.time |replace(':','')}}"
 datetime_stamp: "{{ date_stamp }}-{{ time_stamp }}"
 local_home: "{{ lookup('env', 'HOME') }}"
-backup_dir: "{{ local_home }}/rpc13-upgrade-{{ date_stamp }}"
+backup_dir: "{{ ansible_env.BKUPDIR |default(local_home+'/'+'rpc-upgrade-'+date_stamp) }}"

--- a/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -13,13 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 - name: Gather openstack CLI version
-  shell: "source ~/openrc; openstack --version 2>&1"
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    openstack --version 2>&1
   args:
     executable: /bin/bash
   register: openstack_cli_version
 
 - name: Gather neutron CLI version
-  shell: "source ~/openrc; neutron --version 2>&1"
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    neutron --version 2>&1
   args:
     executable: /bin/bash
   register: neutron_cli_version
@@ -35,28 +39,36 @@
   delegate_to: "{{ groups['galera_all'][0] }}"
 
 - name: Gather nova service-list
-  shell: "source ~/openrc; nova --insecure service-list"
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    nova {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} service-list
   args:
     executable: /bin/bash
   register: nova_servicelist_result
   delegate_to: "{{ groups['utility_all'][0] }}"
 
 - name: Gather cinder service-list
-  shell: "source ~/openrc; cinder --insecure service-list"
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    cinder {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} service-list
   register: cinder_servicelist_result
   args:
     executable: /bin/bash
   delegate_to: "{{ groups['utility_all'][0] }}"
 
 - name: Gather neutron agent-list
-  shell: "source ~/openrc; neutron --insecure agent-list"
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    neutron {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} agent-list
   args:
     executable: /bin/bash
   register: neutron_agentlist_result
   delegate_to: "{{ groups['utility_all'][0] }}"
 
 - name: Gather orchestration service list
-  shell: "source ~/openrc; openstack orchestration service list --insecure"
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    openstack {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} orchestration service list
   args:
     executable: /bin/bash
   register: orchestration_servicelist_result
@@ -64,7 +76,9 @@
   delegate_to: "{{ groups['utility_all'][0] }}"
 
 - name: Gather heat service list
-  shell: "source ~/openrc; heat --insecure service-list"
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    heat {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} service-list
   args:
     executable: /bin/bash
   register: orchestration_servicelist_result
@@ -72,7 +86,9 @@
   delegate_to: "{{ groups['utility_all'][0] }}"
 
 - name: Gather openstack endpoint list
-  shell: "source ~/openrc; openstack --insecure endpoint list"
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    openstack {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} endpoint list
   args:
     executable: /bin/bash
   register: endpointlist_result
@@ -104,14 +120,14 @@
 - name: Obtain a list of neutron routers
   shell: |
     . {{ ansible_env.HOME }}/openrc
-    neutron router-list -f table --column id |awk '/([A-Fa-f0-9]+\-)+[A-Fa-f0-9]+/ {print $2}'
+    neutron {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} router-list -f table --column id |awk '/([A-Fa-f0-9]+\-)+[A-Fa-f0-9]+/ {print $2}'
   register: neutron_routers
   delegate_to: "{{ groups['utility_all'][0] }}"
 
 - name: Check agent assigned to each neutron router
   shell: |
     . {{ ansible_env.HOME }}/openrc
-    neutron l3-agent-list-hosting-router -f table --column host {{ item }} |awk '/([A-Fa-f0-9]+\-)+[A-Fa-f0-9]+/ {print $2}'
+    neutron {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} l3-agent-list-hosting-router -f table --column host {{ item }} |awk '/([A-Fa-f0-9]+\-)+[A-Fa-f0-9]+/ {print $2}'
   with_items: "{{ neutron_routers.stdout_lines }}"
   register: neutron_routers_agents
   delegate_to: "{{ groups['utility_all'][0] }}"


### PR DESCRIPTION
Adding the insecure flag to the rpc_post and pre upgrade roles
for all openstack CLI commands.
Additionally the timestamp for backup_dir is stripped off colons
as it can break tools like tar