### PR TITLE
RLM-1234 Remove xtrabackup from galera_client

### DIFF
--- a/playbooks/patches/liberty/galera_client/galera_client_remove_percona_xtrabackup.patch
+++ b/playbooks/patches/liberty/galera_client/galera_client_remove_percona_xtrabackup.patch
@@ -1,0 +1,42 @@
+diff --git a/playbooks/roles/galera_client/tasks/galera_client_install.yml b/playbooks/roles/galera_client/tasks/galera_client_install.yml
+index b7d012d..4d82e6c 100644
+--- a/playbooks/roles/galera_client/tasks/galera_client_install.yml
++++ b/playbooks/roles/galera_client/tasks/galera_client_install.yml
+@@ -53,13 +53,6 @@
+   tags:
+     - galera-client-apt-packages
+
+-- name: Install galera package
+-  apt:
+-    deb: "{{ galera_client_package_path }}"
+-    force: yes
+-  tags:
+-    - galera-client-apt-packages
+-
+ - name: Install pip packages
+   pip:
+     name: "{{ item }}"
+diff --git a/playbooks/roles/galera_client/tasks/galera_client_pre_install.yml b/playbooks/roles/galera_client/tasks/galera_client_pre_install.yml
+index df0ff2c..0afa7dd 100644
+--- a/playbooks/roles/galera_client/tasks/galera_client_pre_install.yml
++++ b/playbooks/roles/galera_client/tasks/galera_client_pre_install.yml
+@@ -63,19 +63,5 @@
+   delay: 2
+   with_items:
+     - "{{ galera_client_apt_repo }}"
+-    - "{{ galera_client_apt_percona_xtrabackup_repo }}"
+   tags:
+     - galera-client-repos
+-
+-- name: Download the galera package
+-  get_url:
+-    url: "{{ galera_client_package_url }}"
+-    dest: "{{ galera_client_package_path }}"
+-    mode: "0644"
+-    sha256sum: "{{ galera_client_package_sha256 }}"
+-  register: package_download
+-  retries: 3
+-  delay: 10
+-  until: package_download|success
+-  tags:
+-    - galera-client-apt-packages

--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -163,6 +163,14 @@ function fix_galera_apt_cache {
   popd
 }
 
+function remove_xtrabackup_from_galera_client {
+  pushd /opt/rpc-openstack/openstack-ansible
+    if grep 'percona-xtrabackup' /opt/rpc-openstack/openstack-ansible/playbooks/roles/galera_client/defaults/main.yml; then
+      patch -p1 < ${WORKSPACE_PATH}/playbooks/patches/liberty/galera_client/galera_client_remove_percona_xtrabackup.patch
+    fi
+  popd
+}
+
 function maas_tweaks {
   # RLM-518 older versions of liberty did not set maas_swift_accesscheck_password
   if ! grep '^maas_swift_accesscheck_password\:' /opt/rpc-openstack/rpcd/etc/openstack_deploy/user_extras_secrets.yml; then
@@ -229,6 +237,7 @@ pushd /opt/rpc-openstack
     allow_frontloading_vars
     get_ssh_role
     fix_galera_apt_cache
+    remove_xtrabackup_from_galera_client
     maas_tweaks
     # NOTE(cloudnull): The global requirement pins for early Liberty are broken.
     #                  This pull the pins forward so that we can continue with


### PR DESCRIPTION
xtrabackup is only required for galera_server so
remove it if present in liberty in the
galera_client install.