### PR TITLE
Remove percona-xtrabackup-22 conflict

### DIFF
--- a/playbooks/patches/liberty/galera_server/galera_server_apt_repo_defaults.patch
+++ b/playbooks/patches/liberty/galera_server/galera_server_apt_repo_defaults.patch
@@ -1,5 +1,5 @@
 diff --git a/playbooks/roles/galera_server/defaults/main.yml b/playbooks/roles/galera_server/defaults/main.yml
-index 6f84c07..fcf2c7d 100644
+index 6f84c07a..fcf2c7d5 100644
 --- a/playbooks/roles/galera_server/defaults/main.yml
 +++ b/playbooks/roles/galera_server/defaults/main.yml
 @@ -75,7 +75,7 @@ galera_gpg_keys:
@@ -29,3 +29,16 @@ index 6f84c07..fcf2c7d 100644
 +  - libev4
    - python-software-properties
    - software-properties-common
+
+diff --git a/playbooks/roles/galera_server/tasks/galera_install.yml b/playbooks/roles/galera_server/tasks/galera_install.yml
+index 71dce4c2..ce1720e3 100644
+--- a/playbooks/roles/galera_server/tasks/galera_install.yml
++++ b/playbooks/roles/galera_server/tasks/galera_install.yml
+@@ -60,6 +60,7 @@
+     state: absent
+   with_items:
+     - percona-xtrabackup
++    - percona-xtrabackup-22
+     - xtrabackup
+   tags:
+     - galera-apt-packages


### PR DESCRIPTION
The installation of xtrabackup >2.2 is conflicting with the older
percona-xtrabackup-22 package and need to be removed if installed