### PR TITLE
RLM-271 Remove ansible_ssh from all user configs

### DIFF
--- a/scripts/pre_leap.sh
+++ b/scripts/pre_leap.sh
@@ -26,12 +26,7 @@ export CONTAINERS_TO_DESTROY=${CONTAINERS_TO_DESTROY:-'all_containers:!galera_al
 # Branches lower than Newton may have ansible_host: ansible_ssh_host mapping
 # that will fail because ansible_ssh_host is undefined on ansible 2.1
 # Strip it.
-if [[ -f /etc/openstack_deploy/user_rpcm_default_variables.yml ]]; then
-    sed -i '/ansible_host/d' /etc/openstack_deploy/user_rpcm_default_variables.yml
-fi
-if [[ -f /etc/openstack_deploy/user_rpco_variables_overrides.yml ]]; then
-    sed -i '/ansible_host/d' /etc/openstack_deploy/user_rpco_variables_overrides.yml
-fi
+sed -i '/ansible_host/d' /etc/openstack_deploy/user*.yml
 
 # Remove horizon static files variables from user_variables.yml as this is now
 # maintained in group_vars.


### PR DESCRIPTION
ansible_ssh can be configured in any of the user yml
configuration files, which is mainly set below Newton releases
to roll out MAAS. As it breaks ansible 2.1 we need to remove it
from all occurences rather than just named files.