### PR TITLE
RE-1162 Replace Travis CI usage

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -11,7 +11,6 @@ env
 echo "+-------------------- ENV VARS --------------------+"
 
 ## Vars ----------------------------------------------------------------------
-export FUNCTIONAL_TEST=${FUNCTIONAL_TEST:-true}
 
 # These vars are set by the CI environment, but are given defaults
 # here to cater for situations where someone is executing the test
@@ -59,7 +58,7 @@ fi
 # dump all RE_ vars to file so it can be sourced for MNAIO
 env | grep RE_ | sed 's/^/export /' > /opt/rpc-upgrades/RE_ENV
 
-if [ "${FUNCTIONAL_TEST}" = true ]; then
+if [ "${RE_JOB_ACTION}" != "tox-test" ]; then
   sudo -H --preserve-env ./run-bindep.sh
   sudo -H --preserve-env pip install -r test-requirements.txt
   sudo -H --preserve-env ./tests/prepare-rpco.sh
@@ -79,5 +78,5 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
     #sudo -H --preserve-env ./tests/run-tempest.sh
   fi
 else
-  sudo -H --preserve-env tox
+  sudo -H --preserve-env tox -e ${RE_JOB_SCENARIO}
 fi


### PR DESCRIPTION
This commit replaces the Travis CI usage with jobs defined and run
within the standard rpc-gating Jenkins environment.  The environment
variable FUNCTIONAL_TEST is removed and instead we check if
RE_JOB_ACTION is not set to "tox-test" to determine if the functional
test should run.  Otherwise, we run tox w/ the specific environment
passed in via RE_JOB_SCENARIO.

NOTE: The .travis.yml file will be removed in a subsequent review.