### PR TITLE
[RLM-273]Add duplicate flavor IDs check

### DIFF
--- a/playbooks/preflight-check.yml
+++ b/playbooks/preflight-check.yml
@@ -112,7 +112,7 @@
   hosts: utility_all[0]
   tasks:
     - name: Get duplicate flavor IDs
-      shell: ". ~/openrc; nova flavor-list | awk '$2 {print $2}' | uniq -D"
+      shell: ". ~/openrc; nova {{ openrc_insecure | default(false) | bool | ternary('--insecure','') }} flavor-list | awk '$2 {print $2}' | uniq -D"
       register: flavor_check
 
     - name: Duplicate flavors exist

--- a/playbooks/preflight-check.yml
+++ b/playbooks/preflight-check.yml
@@ -107,3 +107,14 @@
       register: required_user_config_keys
   tags:
     - leap-key-check
+
+- name: check duplicate nova flavor IDs
+  hosts: utility_all[0]
+  tasks:
+    - name: Get duplicate flavor IDs
+      shell: ". ~/openrc; nova flavor-list | awk '$2 {print $2}' | uniq -D"
+      register: flavor_check
+
+    - name: Duplicate flavors exist
+      fail: msg="Duplicated flavor IDs are detected."
+      when: flavor_check.stdout != ""


### PR DESCRIPTION
Duplicate nova flavor exisiting would cause 'nova-manage db sync' failed
at the mirgration step. This check could prevent this case happened adn
let user have chance to cleanup db before leapupgrade.