### PR TITLE
Add var to override running of upgrade in tests

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -12,6 +12,7 @@ echo "+-------------------- ENV VARS --------------------+"
 
 ## Vars ----------------------------------------------------------------------
 export FUNCTIONAL_TEST=${FUNCTIONAL_TEST:-true}
+export RUN_UPGRADE=${RUN_UPGRADE:-true}
 
 # These vars are set by the CI environment, but are given defaults
 # here to cater for situations where someone is executing the test
@@ -65,18 +66,23 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   sudo -H --preserve-env ./tests/prepare-rpco.sh
   if [ "${RE_JOB_IMAGE_TYPE}" = "mnaio" ]; then
     sudo -H --preserve-env ./tests/create-mnaio.sh
+    if [ "${RUN_UPGRADE}" = true ]; then
+      sudo -H --preserve-env ./tests/upgrade-mnaio.sh
+    fi
   else
     sudo -H --preserve-env ./tests/create-aio.sh
     sudo -H --preserve-env ./tests/maas-install.sh
-    sudo -H --preserve-env ./tests/test-upgrade.sh
-    sudo -H --preserve-env ./tests/maas-install.sh
-    sudo -H --preserve-env ./tests/qc-test.sh
-    # RLM-292 secondary test-upgrade run to validate idempotency
-    export RUN_PREFLIGHT=no
-    sudo -H --preserve-env ./tests/test-upgrade.sh
-    # RLM-293 secondary qc run after test-upgrade attempt
-    sudo -H --preserve-env ./tests/qc-test.sh
-    #sudo -H --preserve-env ./tests/run-tempest.sh
+    if [ "${RUN_UPGRADE}" = true ]; then
+      sudo -H --preserve-env ./tests/test-upgrade.sh
+      sudo -H --preserve-env ./tests/maas-install.sh
+      sudo -H --preserve-env ./tests/qc-test.sh
+      # RLM-292 secondary test-upgrade run to validate idempotency
+      export RUN_PREFLIGHT=no
+      sudo -H --preserve-env ./tests/test-upgrade.sh
+      # RLM-293 secondary qc run after test-upgrade attempt
+      sudo -H --preserve-env ./tests/qc-test.sh
+      #sudo -H --preserve-env ./tests/run-tempest.sh
+    fi
   fi
 else
   sudo -H --preserve-env tox

--- a/testing.rst
+++ b/testing.rst
@@ -42,6 +42,9 @@ built and then the upgrade tools executed against it. This will
 allow for the rapid testing and proto-typing within a localized
 environment.
 
+If you wish to turn the upgrade off for testing prior to upgrade
+you can set `RUN_UPGRADE` to false and then manually upgrade.
+
 ======================================
 Creating a test MNAIO (Multi Node AIO)
 ======================================
@@ -67,3 +70,7 @@ This should kick off the Multi Node AIO build, then prep the
 rpc-openstack, push the configs to infra1 and boot start the
 RPC-O deploy from there.  By default an Ubuntu 14.04 LTS
 (trusty) image is used for the VMs for all leapfrog jobs.
+
+If you wish to turn the upgrade off for testing prior to upgrade
+you can set `RUN_UPGRADE` to false and then manually upgrade.
+

--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -171,21 +171,7 @@ ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
               tests/maas-install.sh"
 echo "MaaS Install and Verify Post Deploy completed..."
 
-# Run Leapfrog upgrade
-${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
-              source /opt/rpc-upgrades/tests/ansible-env.rc; \
-              pushd /opt/rpc-upgrades; \
-              tests/test-upgrade.sh"
-echo "Leapfrog completed..."
-
-# Install and Verify MaaS post leapfrog
-${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
-              source /opt/rpc-upgrades/tests/ansible-env.rc; \
-              pushd /opt/rpc-upgrades; \
-              tests/maas-install.sh"
-echo "MaaS Install and Verify Post Leapfrog completed..."
-
-# Run final QC Tests
+# Run QC Tests
 ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
               source /opt/rpc-upgrades/tests/ansible-env.rc; \
               pushd /opt/rpc-upgrades; \

--- a/tests/upgrade-mnaio.sh
+++ b/tests/upgrade-mnaio.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -evu
+
+# ssh command used to execute tests on infra1
+export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
+
+# Run Leapfrog upgrade
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+              source /opt/rpc-upgrades/tests/ansible-env.rc; \
+              pushd /opt/rpc-upgrades; \
+              tests/test-upgrade.sh"
+echo "Leapfrog completed..."
+
+# Install and Verify MaaS post leapfrog
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+              source /opt/rpc-upgrades/tests/ansible-env.rc; \
+              pushd /opt/rpc-upgrades; \
+              tests/maas-install.sh"
+echo "MaaS Install and Verify Post Leapfrog completed..."
+
+# Run QC Tests
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+              source /opt/rpc-upgrades/tests/ansible-env.rc; \
+              pushd /opt/rpc-upgrades; \
+              tests/qc-test.sh"
+echo "QC Tests completed..."


### PR DESCRIPTION
Currently we upgrade no matter what the user is trying to in the
tests directory of scripts. This commit adds an override variable
to allow the tester to choose whether to upgrade or not at run time
of the build.sh script. This will allow the user to have more granular
control when testing