### PR TITLE
Split MNAIO Upgrade from MNAIO Create Script

### DIFF
--- a/gating/pre_merge_test/run
+++ b/gating/pre_merge_test/run
@@ -66,6 +66,9 @@ if [ "${FUNCTIONAL_TEST}" = true ]; then
   sudo -H --preserve-env ./tests/prepare-rpco.sh
   if [ "${RE_JOB_IMAGE_TYPE}" = "mnaio" ]; then
     sudo -H --preserve-env ./tests/create-mnaio.sh
+    if [[ "$RUN_UPGRADES" == "yes" ]]; then
+      sudo -H --preserve-env ./tests/upgrade-mnaio.sh
+    fi
   else
     sudo -H --preserve-env ./tests/create-aio.sh
     sudo -H --preserve-env ./tests/maas-install.sh

--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -172,26 +172,9 @@ ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
               tests/maas-install.sh"
 echo "MaaS Install and Verify Post Deploy completed..."
 
-if [[ "$RUN_UPGRADES" == "yes" ]]; then
-  # Run Leapfrog upgrade
-  ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
-                source /opt/rpc-upgrades/tests/ansible-env.rc; \
-                pushd /opt/rpc-upgrades; \
-                tests/test-upgrade.sh"
-  echo "Leapfrog completed..."
-
-  # Install and Verify MaaS post leapfrog
-  ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
-                source /opt/rpc-upgrades/tests/ansible-env.rc; \
-                pushd /opt/rpc-upgrades; \
-                tests/maas-install.sh"
-  echo "MaaS Install and Verify Post Leapfrog completed..."
-
-  # Run final QC Tests
-  ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
-                source /opt/rpc-upgrades/tests/ansible-env.rc; \
-                pushd /opt/rpc-upgrades; \
-                tests/qc-test.sh"
-  echo "QC Tests completed..."
-fi
-
+# Run QC Tests
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+              source /opt/rpc-upgrades/tests/ansible-env.rc; \
+              pushd /opt/rpc-upgrades; \
+              tests/qc-test.sh"
+echo "QC Tests completed..."

--- a/tests/upgrade-mnaio.sh
+++ b/tests/upgrade-mnaio.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Shell Opts ----------------------------------------------------------------
+
+set -evu
+
+echo "Upgrading a Multi Node AIO (MNAIO)"
+echo "+-------------------- MNAIO ENV VARS --------------------+"
+env
+echo "+-------------------- MNAIO ENV VARS --------------------+"
+
+# ssh command used to execute tests on infra1
+export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
+
+# Run Leapfrog upgrade
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+              source /opt/rpc-upgrades/tests/ansible-env.rc; \
+              pushd /opt/rpc-upgrades; \
+              tests/test-upgrade.sh"
+echo "Leapfrog completed..."
+
+# Install and Verify MaaS post leapfrog
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+              source /opt/rpc-upgrades/tests/ansible-env.rc; \
+              pushd /opt/rpc-upgrades; \
+              tests/maas-install.sh"
+echo "MaaS Install and Verify Post Leapfrog completed..."
+
+# Run QC Tests
+${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
+              source /opt/rpc-upgrades/tests/ansible-env.rc; \
+              pushd /opt/rpc-upgrades; \
+              tests/qc-test.sh"
+echo "QC Tests completed..."


### PR DESCRIPTION
This commit pulls the MNAIO upgrade out of the
MNAIO create script and puts it into its own
script so that testers can call the upgrade at
a later time if needed