### PR TITLE
Fix bashate error

### DIFF
--- a/gating/pre_merge_test/post
+++ b/gating/pre_merge_test/post
@@ -61,3 +61,4 @@ if which lxc-ls &> /dev/null; then
 fi
 
 echo "#### END LOG COLLECTION ###"
+


### PR DESCRIPTION
E004: File did not end with a newline