### PR TITLE
RLM-1338 Set pin of setuptools if not set

### DIFF
--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -221,6 +221,12 @@ pushd /opt/rpc-openstack
     # NOTE(cloudnull): Pycrypto has to be limited.
     sed -i 's|pycrypto.*|pycrypto<=2.6.1|g' ${OSA_PATH}/requirements.txt
 
+    # RLM-1338 Older versions of kilo that use older setuptools fail with install_requires
+    # must be a string  or list of strings so use the latest version that will work
+    if ! grep 'setuptools' ${OSA_PATH}/requirements.txt; then
+      echo -e "setuptools==21.0.0\n" | tee ${OSA_PATH}/requirements.txt
+    fi
+
     # NOTE(cloudnull): Early kilo versions forced repo-clone from our mirrors.
     #                  Sadly this takes forever and is largely broken. This
     #                  changes the default behaviour to build.


### PR DESCRIPTION
Older versions of kilo that use older setuptools fail
with install_requires must be a string  or list of strings
so use the latest version that will work.  Uses the version in
r11.1.9.