### PR TITLE
RLM-1373 Purge Glance cache before preflight check

### DIFF
--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -72,6 +72,16 @@ if [[ ! -d "${UPGRADE_LEAP_MARKER_FOLDER}" ]]; then
     mkdir -p "${UPGRADE_LEAP_MARKER_FOLDER}"
 fi
 
+# Glance cache cleanup
+if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/glance-cache-cleanup.complete" ]]; then
+  pushd /opt/rpc-upgrades/playbooks/
+    openstack-ansible glance-cache-cleanup.yml
+  popd
+  log "glance-cache-cleanup" "ok"
+else
+  log "glance-cache-cleanup" "skipped"
+fi
+
 # Pre-flight check
 if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/rpc-preflight-check.complete" ]]; then
   if [[ "$RUN_PREFLIGHT" == "yes" ]]; then
@@ -82,16 +92,6 @@ if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/rpc-preflight-check.complete" ]]; then
   log "rpc-preflight-check" "ok"
 else
   log "rpc-preflight-check" "skipped"
-fi
-
-# Glance cache cleanup
-if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/glance-cache-cleanup.complete" ]]; then
-  pushd /opt/rpc-upgrades/playbooks/
-    openstack-ansible glance-cache-cleanup.yml
-  popd
-  log "glance-cache-cleanup" "ok"
-else
-  log "glance-cache-cleanup" "skipped"
 fi
 
 # Let's go


### PR DESCRIPTION
Purges Glance cache before preflight in order to prevent errors in
preflight from no space on glace nodes.