### PR TITLE
RLM-1368 Use latest release tag for gate jobs

### DIFF
--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -18,7 +18,7 @@ set -evu
 
 export VALIDATE_UPGRADE_INPUT=false
 export AUTOMATIC_VAR_MIGRATE_FLAG="--for-testing-take-new-vars-only"
-export RPC_TARGET_CHECKOUT=${RE_JOB_UPGRADE_TO:-'newton'}
+export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'newton'}
 
 if [ "${RE_JOB_SERIES}" == "kilo" ]; then
   export UPGRADE_ELASTICSEARCH=no

--- a/tests/test-upgrade.sh
+++ b/tests/test-upgrade.sh
@@ -16,6 +16,16 @@
 
 set -evu
 
+export RPC_TARGET_CHECKOUT=${RE_JOB_UPGRADE_TO:-'newton'}
+if [[ ${RE_JOB_UPGRADE_TO} == "r14.current" ]]; then
+  pushd /opt/rpc-openstack
+    echo "Getting latest tagged release for r14.current..."
+    git fetch --tags
+    RPC_TARGET_CHECKOUT=`git for-each-ref refs/tags --sort=-taggerdate --format='%(tag)' | grep r14. | head -1`
+    echo "Upgrading to latest release of ${RPC_TARGET_CHECKOUT} (Newton)..."
+  popd
+fi
+
 if [ "${RE_JOB_UPGRADE_ACTION}" == "leap" ]; then
   tests/test-leapfrog.sh
 elif [ "${RE_JOB_UPGRADE_ACTION}" == "major" ]; then


### PR DESCRIPTION
Allows us to use statically named gate jobs for releases
so that we don't have to change the gate jobs monthly.

Looks for 14.RELEASE in the leap to part of the configuation
and if set, determines the latest r14. tag from RPC-O.