### PR TITLE
Make Neutron routers optional

### DIFF
--- a/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -136,5 +136,5 @@
   copy:
     content: "{{ item.stdout|replace('_','-') }}" # we replace here since containers will get renamed during upgrade
     dest: "{{ backup_dir }}/{{ item.item }}.pre-upgrade"
-  with_items: "{{ neutron_routers_agents.results }}"
+  with_items: "{{ neutron_routers_agents.results |default([]) }}"
   delegate_to: localhost


### PR DESCRIPTION
The rpc pre upgrade role was expecting neutron routers
to be installed and write out their status information.
As neutron routers are optional, the task to write the
status file is changed to default to an empty list