### PR TITLE
RLM-1340 Set serialization to 100%

### DIFF
--- a/scripts/post_leap.sh
+++ b/scripts/post_leap.sh
@@ -48,6 +48,9 @@ else
   log "deploy-rpc" "skipped"
 fi
 
+# remove user_leapfrog_overrides.yml as it contains values used during the leapfrog process
+rm -f /etc/openstack_deploy/user_leapfrog_overrides.yml
+
 if [ "QC_TEST" == "yes" ]; then
   . /opt/rpc-upgrades/tests/qc-test.sh
 fi


### PR DESCRIPTION
Since leapfrog is 100% API downitme, remove the throttle to
keep the APIs operational.

Also moves optimizations for improving leapfrog deploy speeds into
user_leapfrog_overrides.yml which is removed after a successful
leap since those values are mainly beneficial during the leapfrog.