### PR TITLE
RLM-1437 Force kill logstash if graceful fails

### DIFF
--- a/playbooks/elasticsearch-reindex.yml
+++ b/playbooks/elasticsearch-reindex.yml
@@ -19,15 +19,18 @@
   roles:
     - role: "pip_install"
 
-- name: Stop logstash serivce
+- name: Stop logstash service
   hosts: logstash_all
   user: root
   tasks:
-    - name: Service stop
+    - name: Attempt to gracefully stop logstash
       service:
         name: logstash
         state: stopped
         pattern: logstash
+    - name: Force kill logstash
+      shell: "pkill -f -9 logstash"
+  ignore_errors: true
 
 - name: New session to reindex Elasticsearch
   hosts: localhost


### PR DESCRIPTION
Force kills logstash if a graceful shutdown fails.  Gate jobs
were occasionally failing on trying to shutdown the service
so this attempts to shutdown gracefully before killing the
service.