### PR TITLE
RLM-1438 Ensure we're using openstack_hosts fork

### DIFF
--- a/playbooks/patches/newton/rpc-o-14.7.0-ansible-role-requirements.patch
+++ b/playbooks/patches/newton/rpc-o-14.7.0-ansible-role-requirements.patch
@@ -1,0 +1,12 @@
+diff --git a/ansible-role-requirements.yml b/ansible-role-requirements.yml
+index b06b3c17..ef372711 100644
+--- a/ansible-role-requirements.yml
++++ b/ansible-role-requirements.yml
+@@ -10,3 +10,7 @@
+   scm: git
+   src: https://github.com/ceph/ansible-ceph-osd.git
+   version: 434a13f4d3ee3f60c410052d2670d5dfea034bf8
++- name: openstack_hosts
++  scm: git
++  src: https://github.com/rcbops/openstack-ansible-openstack_hosts
++  version: 235ec6f0fc5570e7c657b243bcf4208cc2c7739c

--- a/scripts/pre_redeploy.sh
+++ b/scripts/pre_redeploy.sh
@@ -135,3 +135,10 @@ cinder_api_serial: '100%'
 glance_api_serial: '100%'
 glance_registry_rolling: '100%'
 EOF
+
+# RLM-1438 patch openstack_hosts fork into 14.7.0 to ensure RLM-322 works
+if [[ ${RPC_TARGET_CHECKOUT} == "r14.7.0" ]]; then
+   pushd ${RPCO_DEFAULT_FOLDER}
+     patch -p1 < ${RPC_UPGRADES_DEFAULT_FOLDER}/patches/newton/rpc-o-14.7.0-ansible-role-requirements.patch
+   popd
+fi


### PR DESCRIPTION
Injects the openstack_hosts fork on 14.7.0 which
includes the domain fixes for RLM-322.