### PR TITLE
Revert RLM-1401 and correct osa overrides use

### DIFF
--- a/scripts/pre_redeploy.sh
+++ b/scripts/pre_redeploy.sh
@@ -104,23 +104,14 @@ if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/configure-apt-sources-rpc.complete" ]]
     log "configure-apt-sources-rpc" "ok"
 fi
 
-# RLM-322 Set openstack_domain to empty which makes fqdns hostname correct
+# RLM-322 Set openstack_domain to blank to preserve short hostnames, 
+#         if not otherwise configured.
 pushd /etc/openstack_deploy/
-    sed -i '/^openstack_domain.*/d' user_osa_variables_defaults.yml
-    echo "openstack_domain: ''" >> user_osa_variables_defaults.yml
+    grep -q 'openstack_domain:' user_*.yml 2>/dev/null || echo "openstack_domain: ''" |tee -a $OA_OVERRIDES
 popd
 
 # RLM-1423 Increase apt cache timeout to cover time to run maintenance
 pushd /etc/openstack_deploy/
-    sed -i '/^cache_timeout.*/d' user_osa_variables_defaults.yml
-    echo "cache_timeout: '21600'" >> user_osa_variables_defaults.yml
-popd
-
-# RLM-1401 Set package_state to present instead of latest to avoid repeated apt updates during leap
-# and sets haproxy_package_state to latest to allow it to read new configuration options
-pushd /etc/openstack_deploy/
-    sed -i '/^package_state.*/d' user_osa_variables_defaults.yml
-    echo "package_state: 'present'" >> user_osa_variables_defaults.yml
-    sed -i '/^haproxy_package_state.*/d' user_osa_variables_defaults.yml
-    echo "haproxy_package_state: 'latest'" >> user_osa_variables_defaults.yml
+    sed -i '/^cache_timeout.*/d' user_*.yml
+    echo "cache_timeout: '21600'" | tee -a user_leapfrog_overrides.yml
 popd


### PR DESCRIPTION
RLM-1401 introduced a unwanted sideeffect that libvirt, qemu and
other packages did not get updated on the hosts, rendering nova-
compute broken.

Also the references inside pre_redploy using
user_osa_variables_defaults.yml are changed to use the
user_osa_variables_overrides.yml as the defaults file is managed by
OSA