### PR TITLE
RLM-1374 Indent Mapped Sequences

### DIFF
--- a/playbooks/scripts/required_user_config_keys.py
+++ b/playbooks/scripts/required_user_config_keys.py
@@ -32,6 +32,17 @@ be considered an exception.
 """
 
 
+class IndentFix(yaml.Dumper):
+    """This address RLM 1374, proper indentation for mapped sequence blocks
+
+    Pass this as the Dumper class when making calls to yaml.dump() to ensure
+    indentation remains consistent.
+    """
+
+    def increase_indent(self, flow=False, indentless=False):
+        return super(IndentFix, self).increase_indent(flow, False)
+
+
 def key_check_add(key, user_config_file, changed=False):
     """Add key if missing in the openstack_user_config.yml
 
@@ -71,7 +82,8 @@ def key_check_add(key, user_config_file, changed=False):
                 yaml.dump(
                     user_config,
                     default_flow_style=False,
-                    width=1000
+                    width=1000,
+                    Dumper=IndentFix
                 )
             )
 


### PR DESCRIPTION
The fix here is based on this[ SO answer](https://stackoverflow.com/questions/25108581/python-yaml-dump-bad-indentation?utm_medium=organic&utm_source=google_rich_qa&utm_campaign=google_rich_qa).  I know that the ticket for this PR suggests quoting as the culprit, but logs and online discussion suggest some parsers just don't like the lack of indentation.  Even yamllint logs the lack of indentation as an error, even though PyYaml notes that indentation is explicitly optional in the YAML spec.


For Clarity:
```yaml
used_ips: #bueno
  - 10.52.4.1,10.52.4.50
  - 10.52.7.1,10.52.7.50
  - 10.52.8.1,10.52.8.50
  - 10.52.10.1,10.52.10.50
```

```yaml
used_ips: #no bueno
- 10.52.4.1,10.52.4.50
- 10.52.7.1,10.52.7.50
- 10.52.8.1,10.52.8.50
- 10.52.10.1,10.52.10.50
```

I tested this against the YAML files provided in the ticket discussion and it works nicely.

I suspect there is a better place to define the IndentFix class, and possibly a more cromulent name to give it.  Otherwise I feel confident this is the right fix.