### PR TITLE
RLM-1456 Force user to export release version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,12 @@ the upgrade by setting these environment variables:
 
    export RPC_TARGET_CHECKOUT=r14.7.0
 
+If you cannot locate `/etc/openstack-release` or it is outdated. Export the release version which upgrade from manually:
+
+.. code-block:: shell
+
+    export CODE_UPGRADE_FROM='KILO/LIBERTY'
+
 The next step is to execute the leapfrog upgrade script and follow the prompts:
 
 .. code-block:: shell

--- a/playbooks/preflight-check.yml
+++ b/playbooks/preflight-check.yml
@@ -21,19 +21,26 @@
     - name: Ping check
       ping:
 
-- name: Openstack release check
+- name: Openstack release check if exists 
   hosts: localhost
   gather_facts: false
   user: root
   tasks:
-    - name: Get Openstack release
-      shell: grep 'DISTRIB_RELEASE' /etc/openstack-release | sed -e 's/.*"\(.*\)"/\1/'
-      register: openstack_release_return
+    - stat:
+        path: /etc/openstack-release
+      register: openstack_release_stat
 
-    - name: Check Openstack release
+    - stat:
+        path: /etc/rpc-release
+      register: rpc_release_stat
+
+    - name: Check release upgrade from
       fail:
-        msg: "Current Openstack release version is higher than Newton, and leapfrog isn't appliable."
-      when: "{{ openstack_release_return.stdout | version_compare('14.0.0', '>=') }}"
+        msg: "Cannot find neither openstack-release file nor rpc-release, this will cause problem during leapupgrade. Please copy it from other hosts or generate a correct one. You can skip this check by passing the option 'enable_openstack_release_check=false'."
+      when:
+        - openstack_release_stat.stat.exists == False
+        - rpc_release_stat.stat.exists == False
+        - enable_openstack_release_check | default(true) | bool
 
 - name: Ceph check
   hosts: "ceph_all:ceph_mon_container:ceph_osd_container"

--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -83,6 +83,15 @@ else
   log "glance-cache-cleanup" "skipped"
 fi
 
+# RLM-1456 Define right release to $CODE_UPGRADE_FROM by marker file
+if [[ -f ${UPGRADE_LEAP_MARKER_FOLDER}/db-migrations-mitaka.yml* ]]; then
+    export $CODE_UPGRADE_FROM='MITAKA'
+fi
+
+if [[ -f ${UPGRADE_LEAP_MARKER_FOLDER}/db-migrations-newton.yml* ]]; then
+    export $CODE_UPGRADE_FROM='NEWTON'
+fi
+
 # Pre-flight check
 if [[ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/rpc-preflight-check.complete" ]]; then
   if [[ "$RUN_PREFLIGHT" == "yes" ]]; then


### PR DESCRIPTION
Ideally users don't need worry about release upgrade from since
openstack-release can give the version. In fact at most of time it
cannot guarantee giving proper release info, especially the file not on
infra node or outdated. This check will force user to export correct
release name.