### PR TITLE
Install libvirt-dev for libvirt-python dependency

### DIFF
--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -138,6 +138,8 @@ sudo cp /etc/openstack_deploy/user_variables.yml.bak /etc/openstack_deploy/user_
 sudo cp /opt/rpc-openstack/rpcd/etc/openstack_deploy/user_*.yml /etc/openstack_deploy
 sudo cp /opt/rpc-openstack/rpcd/etc/openstack_deploy/env.d/* /etc/openstack_deploy/env.d
 sudo pip uninstall ansible -y
+# install libvirt-dev on infra1 because pinning to libvirt-python requires it
+sudo apt-get -y install libvirt-dev
 sudo rm /usr/local/bin/openstack-ansible
 EOF
 


### PR DESCRIPTION
Install libvirt-dev for libvirt-python dependency to fix this error, should get MNAIO working for kilo as well.
```
11:11:52 Requirement already satisfied (use --upgrade to upgrade): six in /usr/lib/python2.7/dist-packages (from singledispatch->tornado==4.5.3->-r requirements.txt (line 14))
11:11:52 Building wheels for collected packages: libvirt-python
11:11:52   Running setup.py bdist_wheel for libvirt-python: started
11:11:53   Running setup.py bdist_wheel for libvirt-python: finished with status 'error'
11:11:53   Complete output from command /usr/bin/python2 -u -c "import setuptools, tokenize;__file__='/tmp/pip-build-Dz1SHk/libvirt-python/setup.py';exec(compile(getattr(tokenize, 'open', open)(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" bdist_wheel -d /tmp/tmpngymKLpip-wheel- --python-tag cp27:
11:11:53   running bdist_wheel
11:11:53   running build
11:11:53   Traceback (most recent call last):
11:11:53     File "<string>", line 1, in <module>
11:11:53     File "/tmp/pip-build-Dz1SHk/libvirt-python/setup.py", line 366, in <module>
11:11:53       "Programming Language :: Python :: 3",
11:11:53     File "/usr/lib/python2.7/distutils/core.py", line 151, in setup
11:11:53       dist.run_commands()
11:11:53     File "/usr/lib/python2.7/distutils/dist.py", line 953, in run_commands
11:11:53       self.run_command(cmd)
11:11:53     File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
11:11:53       cmd_obj.run()
11:11:53     File "/usr/local/lib/python2.7/dist-packages/wheel/bdist_wheel.py", line 176, in run
11:11:53       self.run_command('build')
11:11:53     File "/usr/lib/python2.7/distutils/cmd.py", line 326, in run_command
11:11:53       self.distribution.run_command(command)
11:11:53     File "/usr/lib/python2.7/distutils/dist.py", line 972, in run_command
11:11:53       cmd_obj.run()
11:11:53     File "/tmp/pip-build-Dz1SHk/libvirt-python/setup.py", line 147, in run
11:11:53       check_minimum_libvirt_version()
11:11:53     File "/tmp/pip-build-Dz1SHk/libvirt-python/setup.py", line 40, in check_minimum_libvirt_version
11:11:53       spawn([get_pkgcfg(),
11:11:53     File "/tmp/pip-build-Dz1SHk/libvirt-python/setup.py", line 36, in get_pkgcfg
11:11:53       raise Exception("pkg-config binary is required to compile libvirt-python")
11:11:53   Exception: pkg-config binary is required to compile libvirt-python
11:11:53   
```