### PR TITLE
RLM-1374  Malformed YAML 2: Electric Boogaloo

### DIFF
--- a/playbooks/scripts/required_user_config_keys.py
+++ b/playbooks/scripts/required_user_config_keys.py
@@ -83,6 +83,8 @@ def key_check_add(key, user_config_file, changed=False):
                     user_config,
                     default_flow_style=False,
                     width=1000,
+                    explicit_start=True,
+                    explicit_end=False,
                     Dumper=IndentFix
                 )
             )


### PR DESCRIPTION
This ensures that the user config starts with `---`

The added ` explicit_end=False,` is added in hopes that it might address sightings of `---` in places other than the beginning of the document.