### PR TITLE
RLM-1465 Bump rpc-upgrades to r14.11.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Overview
 A Leapfrog upgrade is a major upgrade that skips at least one release. Currently
 rpc-upgrades repo supports supports leapfrog upgrades from:
 
-* liberty to r14.10.0 (newton)
+* liberty to r14.11.0 (newton)
 
 If you are looking for the Kilo to 14.2.0 (newton) support, it exists directly in the
 `RPC-O <https://github.com/rcbops/rpc-openstack/tree/r14.2.0/scripts/leapfrog>`_ repo.  
@@ -24,7 +24,7 @@ Terms
 * `OSA <https://github.com/openstack/openstack-ansible>`_:  OpenStack Ansible
 * `OSA-OPS <https://github.com/openstack/openstack-ansible-ops>`_:  OpenStack Operations
 * `Liberty <https://github.com/rcbops/rpc-openstack/tree/liberty>`_: The RPCO release of OpenStack Liberty
-* `r14.10.0 <https://github.com/rcbops/rpc-openstack/tree/r14.10.0>`_: The RPCO release of OpenStack Newton.
+* `r14.11.0 <https://github.com/rcbops/rpc-openstack/tree/r14.11.0>`_: The RPCO release of OpenStack Newton.
 
 Pre Leapfrog Tasks
 ------------------
@@ -62,11 +62,11 @@ the upgrade by setting these environment variables:
     export CONTAINERS_TO_DESTROY='all_containers:!galera_all:!neutron_agent:!ceph_all:!rsyslog_all'
 
 
-**Note:** *Currently the rpc-upgrades repo targets r14.10.0.  If you want to deploy the previous version you can:*
+**Note:** *Currently the rpc-upgrades repo targets r14.11.0.  If you want to deploy the previous version you can:*
 
 .. code-block:: shell
 
-   export RPC_TARGET_CHECKOUT=r14.7.0
+   export RPC_TARGET_CHECKOUT=r14.10.0
 
 The next step is to execute the leapfrog upgrade script and follow the prompts:
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,12 +18,12 @@ end
 job_actions = [
   "kilo_to_newton_leap",
   "kilo_to_r14.2.0_leap",
-  "kilo_to_r14.10.0_leap",
+  "kilo_to_r14.11.0_leap",
   "liberty_to_newton_leap",
-  "r12.1.2_to_r14.10.0_leap",
-  "r12.2.2_to_r14.10.0_leap",
-  "r12.2.5_to_r14.10.0_leap",
-  "r12.2.8_to_r14.10.0_leap",
+  "r12.1.2_to_r14.11.0_leap",
+  "r12.2.2_to_r14.11.0_leap",
+  "r12.2.5_to_r14.11.0_leap",
+  "r12.2.8_to_r14.11.0_leap",
 ]
 
 Vagrant.configure("2") do |config|

--- a/playbooks/patches/newton/rpc-o-14.11.0-resolv.conf.patch
+++ b/playbooks/patches/newton/rpc-o-14.11.0-resolv.conf.patch
@@ -1,0 +1,46 @@
+diff --git a/group_vars/all/lxc.yml b/group_vars/all/lxc.yml
+index d210ec1f..a170556a 100644
+--- a/group_vars/all/lxc.yml
++++ b/group_vars/all/lxc.yml
+@@ -41,6 +41,8 @@ lxc_cache_prep_pre_commands: |
+     if [ -a /etc/resolv.conf ]; then
+       mv /etc/resolv.conf /etc/resolv.conf.org
+     fi
++    # remove any existing /etc/resolv.conf and start fresh
++    rm /etc/resolv.conf || true
+     # Use the LXC host's dnsmasq service as a resolver
+     echo "nameserver {{ lxc_net_address | default('10.0.3.1') }}" > /etc/resolv.conf
+     # Add the host's repository keys, including the RPC-O keys
+@@ -70,9 +72,3 @@ lxc_cache_prep_pre_commands: |
+       # we reduce the likelihood of conflicts.
+       apt-get install -y --force-yes ${pkg_downgrade_list_versioned}
+     fi
+-    # Return the resolver to its previous state.
+-    if [ -a /etc/resolv.conf.org ]; then
+-      mv /etc/resolv.conf.org /etc/resolv.conf
+-    else
+-      rm -f /etc/resolv.conf
+-    fi
+diff --git a/scripts/artifacts-building/user_rcbops_artifacts_building.yml b/scripts/artifacts-building/user_rcbops_artifacts_building.yml
+index 2a5e2d73..4748b016 100644
+--- a/scripts/artifacts-building/user_rcbops_artifacts_building.yml
++++ b/scripts/artifacts-building/user_rcbops_artifacts_building.yml
+@@ -59,6 +59,8 @@ lxc_cache_prep_pre_commands: |
+     if [ -a /etc/resolv.conf ]; then
+       mv /etc/resolv.conf /etc/resolv.conf.org
+     fi
++    # remove any existing /etc/resolv.conf and start fresh
++    rm /etc/resolv.conf || true
+     # Use the LXC host's dnsmasq service as a resolver
+     echo "nameserver {{ lxc_net_address | default('10.0.3.1') }}" > /etc/resolv.conf
+     # Add the host's repository keys, including the RPC-O keys
+@@ -88,9 +90,3 @@ lxc_cache_prep_pre_commands: |
+       # we reduce the likelihood of conflicts.
+       apt-get install -y --force-yes ${pkg_downgrade_list_versioned}
+     fi
+-    # Return the resolver to its previous state.
+-    if [ -a /etc/resolv.conf.org ]; then
+-      mv /etc/resolv.conf.org /etc/resolv.conf
+-    else
+-      rm -f /etc/resolv.conf
+-    fi

--- a/scripts/pre_redeploy.sh
+++ b/scripts/pre_redeploy.sh
@@ -143,3 +143,11 @@ if [ "${RPC_TARGET_CHECKOUT}" = "r14.7.0" -a ! -f "${UPGRADE_LEAP_MARKER_FOLDER}
      test $? -eq 0 && touch "${UPGRADE_LEAP_MARKER_FOLDER}/patch-rpc-o-14.7.0-ansible-role-requirements.complete"
    popd
 fi
+
+# RLM-1465 patch group_vars/lxc to get around resolv.conf issue
+if [ "${RPC_TARGET_CHECKOUT}" = "r14.11.0" -a ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/patch-rpc-o-14.11.0-resolv.conf.complete" ]; then
+   pushd ${RPCO_DEFAULT_FOLDER}
+     patch -p1 < ${RPC_UPGRADES_DEFAULT_FOLDER}/playbooks/patches/newton/rpc-o-14.11.0-resolv.conf.patch
+     test $? -eq 0 && touch "${UPGRADE_LEAP_MARKER_FOLDER}/patch-rpc-o-14.11.0-resolv.conf.complete"
+   popd
+fi

--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -50,7 +50,7 @@ export POST_LEAP_STEPS="${LEAP_BASE_DIR}/post_leap.sh"
 export RPCD_DEFAULTS='/etc/openstack_deploy/user_rpco_variables_defaults.yml'
 export OA_DEFAULTS='/etc/openstack_deploy/user_osa_variables_defaults.yml'
 # Set the target checkout used when leaping forward.
-export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'r14.10.0'}
+export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'r14.11.0'}
 export RPC_APT_ARTIFACT_MODE=loose
 export QC_TEST=${QC_TEST:-'no'}
 export RUN_PREFLIGHT=${RUN_PREFLIGHT:-yes}

--- a/testing.rst
+++ b/testing.rst
@@ -33,7 +33,7 @@ you wish to test with.
 
 .. code-block:: shell
 
-    export RE_JOB_ACTION=r12.2.8_to_r14.10.0_leap
+    export RE_JOB_ACTION=r12.2.8_to_r14.11.0_leap
     ./run-tests.sh
 
 


### PR DESCRIPTION
Bumps rpc-upgrades to r14.11.0 and includes patch for
fixing resolv.conf issue RLM-1457.  The resolv.conf will be included in
in r14.12.0 but this lets r14.11.0 be usable now.