### PR TITLE
RE-1464 Install pre-requisite packages for MNAIO tests

### DIFF
--- a/gating/pre_merge_test/pre
+++ b/gating/pre_merge_test/pre
@@ -33,7 +33,7 @@ fi
 
 # Install python2 for Ubuntu 16.04 and CentOS 7
 if which apt-get; then
-    sudo apt-get update && sudo apt-get install -y python wget
+    sudo apt-get update && sudo apt-get install -y python wget python-yaml
 fi
 
 if which yum; then


### PR DESCRIPTION
Previously Jenkins made sure that python-yaml was installed
on the host, but with the switch to using nodepool all
pre-requisites must be handled by the test itself.