### PR TITLE
ASC-553 Fix path of inventory for system tests

### DIFF
--- a/tests/run_system_tests.sh
+++ b/tests/run_system_tests.sh
@@ -17,7 +17,7 @@ SYS_TEST_SOURCE_BASE="${SYS_TEST_SOURCE_BASE:-https://github.com/rcbops}"
 SYS_TEST_SOURCE="${SYS_TEST_SOURCE:-rpc-openstack-system-tests}"
 SYS_TEST_SOURCE_REPO="${SYS_TEST_SOURCE_BASE}/${SYS_TEST_SOURCE}"
 SYS_TEST_BRANCH="${RE_JOB_BRANCH:-master}"
-export SYS_INVENTORY="/opt/openstack-ansible/playbooks/inventory"
+export SYS_INVENTORY="/opt/rpc-openstack/openstack-ansible/playbooks/inventory"
 
 ## Main ----------------------------------------------------------------------
 


### PR DESCRIPTION
This commit updates the path for the location of the dynamic inventory
file used by the system tests. This path brings it into compliance with
the `OSA_PATH` used by the installer.