### PR TITLE
ASC-564 Persist release envvars for test results

### DIFF
--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -59,6 +59,8 @@ export RUN_UPGRADES="${RUN_UPGRADES:-yes}"
 # place variable in file to be sourced by parent calling script 'run'
 export MNAIO_VAR_FILE="${MNAIO_VAR_FILE:-/tmp/mnaio_vars}"
 echo "export MNAIO_SSH=\"${MNAIO_SSH}\"" > "${MNAIO_VAR_FILE}"
+echo "export RPC_RELEASE=\"${RPC_RELEASE}\"" >> "${MNAIO_VAR_FILE}"
+echo "export RPC_PRODUCT_RELEASE=\"${RPC_PRODUCT_RELEASE}\"" >> "${MNAIO_VAR_FILE}"
 
 #export ADDITIONAL_COMPUTE_NODES=${env.ADDITIONAL_COMPUTE_NODES}
 #export ADDITIONAL_VOLUME_NODES=${env.ADDITIONAL_VOLUME_NODES}


### PR DESCRIPTION
In order to capture accurate metadata about Molecule system tests, the
"RPC_RELEASE" and "RPC_PRODUCT_RELEASE" environment variables need to be
stored in the "MNAIO_VAR_FILE". Values in this file are re-sourced by the
`run` script to ensure they are used by the system tests in reporting
their results.