### PR TITLE
Revert "ASC-564 Persist release envvars for test results"

### DIFF
--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -59,8 +59,6 @@ export RUN_UPGRADES="${RUN_UPGRADES:-yes}"
 # place variable in file to be sourced by parent calling script 'run'
 export MNAIO_VAR_FILE="${MNAIO_VAR_FILE:-/tmp/mnaio_vars}"
 echo "export MNAIO_SSH=\"${MNAIO_SSH}\"" > "${MNAIO_VAR_FILE}"
-echo "export RPC_RELEASE=\"${RPC_RELEASE}\"" >> "${MNAIO_VAR_FILE}"
-echo "export RPC_PRODUCT_RELEASE=\"${RPC_PRODUCT_RELEASE}\"" >> "${MNAIO_VAR_FILE}"
 
 #export ADDITIONAL_COMPUTE_NODES=${env.ADDITIONAL_COMPUTE_NODES}
 #export ADDITIONAL_VOLUME_NODES=${env.ADDITIONAL_VOLUME_NODES}


### PR DESCRIPTION
This reverts commit 413428bb02e19e2e9bc85c355649144fe8acba5d.

Reverting this commit as it's breaking MNAIO gating as RPC_RELEASE is not defined (unbound variable). We'll need to probably rework this patch.