### PR TITLE
ASC-564 Add release envvars for test results

### DIFF
--- a/tests/run_system_tests.sh
+++ b/tests/run_system_tests.sh
@@ -9,6 +9,16 @@ set -o pipefail
 
 ## Variables -----------------------------------------------------------------
 
+# Release metadata required for qTest export
+if [[ -f /opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh ]]; then
+    export RPC_RELEASE="$(/opt/rpc-openstack/scripts/artifacts-building/derive-artifact-version.sh)"
+elif [[ -f /opt/rpc-openstack/scripts/get-rpc_release.py ]]; then
+    export RPC_RELEASE="$(/opt/rpc-openstack/scripts/get-rpc_release.py -f /opt/rpc-openstack/playbooks/vars/rpc-release.yml)"
+else
+    export RPC_RELEASE=''
+fi
+export RPC_PRODUCT_RELEASE="${RE_JOB_UPGRADE_TO:-newton}"
+
 RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
 export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
 SYS_WORKING_DIR=$(mktemp  -d -t system_test_workingdir.XXXXXXXX)


### PR DESCRIPTION
In order to capture accurate metadata about Molecule system tests, the
"RPC_RELEASE" and "RPC_PRODUCT_RELEASE" environment variables need to be
sourced. For upgrades these are not set by the CI jobs. This commit
ensures that they are created.