### PR TITLE
RE-1590 Prepare rpc-upgrades for using nodepool for PR tests

### DIFF
--- a/gating/check/pre
+++ b/gating/check/pre
@@ -31,13 +31,27 @@ if [[ "$(basename ${PWD})" == "rpc-upgrades" ]]; then
   fi
 fi
 
-# Install python2 for Ubuntu 16.04 and CentOS 7
+# Install required packages for Ubuntu 16.04
+#   curl        - for getting get-pip.py
+#   iptables    - OSA gate-check-commit script expects it on the host
+#   python      - for installing pip using get-pip.py
+#   python-yaml - for ansible and reading yaml files (like the rpc release info)
+#   util-linux  - for the 'lsblk' tool used by OSA gate-check-commit script
+#   wget        - TODO: provide reason for wget's inclusion here
+
 if which apt-get; then
-    sudo apt-get update && sudo apt-get install -y python wget python-yaml
+    sudo apt-get update
+    sudo apt-get install -y curl iptables python python-yaml util-linux wget
 fi
 
+# Install required packages for CentOS 7
+#   curl            - for getting get-pip.py
+#   epel-release    - required to install python-ndg_httpsclient/python2-pyasn1
+#   python          - for installing pip using get-pip.py
+#   redhat-lsb-core - for bindep profile support
+#   wget            - TODO: provide reason for wget's inclusion here
 if which yum; then
-    sudo yum install -y python wget
+    sudo yum install -y curl epel-release python redhat-lsb-core wget
 fi
 
 # Download the get-pip script using the primary or secondary URL
@@ -52,10 +66,3 @@ sudo ${GETPIP_PYTHON_EXEC_PATH} ${GETPIP_FILE} 'pip==9.0.3' 'setuptools==39.0.1'
 
 # Install bindep and tox with pip.
 sudo pip install bindep tox
-
-# CentOS 7 requires two additional packages:
-#   redhat-lsb-core - for bindep profile support
-#   epel-release    - required to install python-ndg_httpsclient/python2-pyasn1
-if which yum; then
-    sudo yum -y install redhat-lsb-core epel-release
-fi

--- a/gating/check/pre
+++ b/gating/check/pre
@@ -40,11 +40,15 @@ if which yum; then
     sudo yum install -y python wget
 fi
 
-# Install pip.
-if ! which pip; then
-  curl --silent --show-error --retry 5 \
-    https://bootstrap.pypa.io/get-pip.py | sudo python2.7
-fi
+# Download the get-pip script using the primary or secondary URL
+GETPIP_CMD="curl --silent --show-error --retry 5"
+GETPIP_FILE="/tmp/get-pip.py"
+GETPIP_PYTHON_EXEC_PATH="$(which python2.7)"
+${GETPIP_CMD} https://bootstrap.pypa.io/get-pip.py > ${GETPIP_FILE}\
+    || ${GETPIP_CMD} https://raw.githubusercontent.com/pypa/get-pip/master/get-pip.py > ${GETPIP_FILE}
+
+# Install specific verison of pip/setuptools/wheel.
+sudo ${GETPIP_PYTHON_EXEC_PATH} ${GETPIP_FILE} 'pip==9.0.3' 'setuptools==39.0.1' 'wheel==0.30.0'
 
 # Install bindep and tox with pip.
 sudo pip install bindep tox

--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -250,7 +250,7 @@ pushd /opt/rpc-openstack
 
     # pin libvirt-python due to issues with 4.1.0
     # https://bugs.launchpad.net/openstack-requirements/+bug/1753539
-    apt-get -y install libvirt-dev
+    apt-get -y install libvirt-dev pkg-config
     if ! grep 'libvirt-python' ${OSA_PATH}/requirements.txt; then
       echo "libvirt-python<=4.0.0" >> ${OSA_PATH}/requirements.txt
     fi

--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -207,6 +207,24 @@ EOF
   fi
 }
 
+function set_aio_hostname {
+  if [[ "$(hostname)" != "aio" ]]; then
+    echo aio1 > /etc/hostname
+    cat > /etc/hosts <<EOF
+127.0.0.1 localhost aio1
+127.0.1.1 aio1.openstack.local aio1
+# The following lines are desirable for IPv6 capable hosts
+::1 ip6-localhost ip6-loopback
+fe00::0 ip6-localnet
+ff00::0 ip6-mcastprefix
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+ff02::3 ip6-allhosts
+EOF
+    hostname aio1
+  fi
+}
+
 ## Main ----------------------------------------------------------------------
 echo "Gate test starting
 with:
@@ -236,6 +254,9 @@ fi
 
 # Enter the RPC-O workspace
 pushd /opt/rpc-openstack
+  if [ "${RE_JOB_IMAGE_TYPE}" == "aio" ]; then
+    set_aio_hostname
+  fi
   if [ "${RE_JOB_SERIES}" == "kilo" ]; then
     git_checkout "kilo"  # Last commit of Kilo
     (git submodule init && git submodule update) || true

--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -193,6 +193,20 @@ function spice_repo_fix_patch {
   popd
 }
 
+function restore_default_apt_sources {
+  if [[ -f "/etc/apt/sources.list.original" ]]; then
+    mv /etc/apt/sources.list.original /etc/apt/sources.list
+  else
+    source /etc/lsb-release
+    cat > /etc/apt/sources.list <<EOF
+deb http://mirror.rackspace.com/ubuntu ${DISTRIB_CODENAME} main universe
+deb http://mirror.rackspace.com/ubuntu ${DISTRIB_CODENAME}-updates main universe
+deb http://mirror.rackspace.com/ubuntu ${DISTRIB_CODENAME}-backports main universe
+deb http://mirror.rackspace.com/ubuntu ${DISTRIB_CODENAME}-security main universe
+EOF
+  fi
+}
+
 ## Main ----------------------------------------------------------------------
 echo "Gate test starting
 with:
@@ -234,6 +248,7 @@ pushd /opt/rpc-openstack
     maas_tweaks
     spice_repo_fix
     spice_repo_fix_patch
+    restore_default_apt_sources
     # NOTE(cloudnull): Pycrypto has to be limited.
     sed -i 's|pycrypto.*|pycrypto<=2.6.1|g' ${OSA_PATH}/requirements.txt
 
@@ -281,6 +296,7 @@ pushd /opt/rpc-openstack
     maas_tweaks
     spice_repo_fix
     spice_repo_fix_patch
+    restore_default_apt_sources
     # NOTE(cloudnull): The global requirement pins for early Liberty are broken.
     #                  This pull the pins forward so that we can continue with
     #                  the AIO deployment for liberty
@@ -295,6 +311,7 @@ pushd /opt/rpc-openstack
     unset_affinity
     allow_frontloading_vars
     spice_repo_fix
+    restore_default_apt_sources
   elif [ "${RE_JOB_SERIES}" == "newton" ]; then
     git_checkout "newton"  # Last commit of Newton
     (git submodule init && git submodule update) || true


### PR DESCRIPTION
This PR prepares rpc-upgrades to make use of nodepool for PR functional tests. Please see the individual commits for changes made and the reasons for them.

Test for ``PR_rpc-upgrades-master-trusty_aio-swift-kilo_to_newton_leap``:
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-upgrades-master-trusty_aio-swift-kilo_to_newton_leap-testjp/10/

Test for ``PR_rpc-upgrades-master-trusty_aio-swift-liberty_to_newton_leap``:
https://rpc.jenkins.cit.rackspace.net/job/PM_rpc-upgrades-master-trusty_aio-swift-liberty_to_newton_leap-testjp/3/