### PR TITLE
FLEEK-61 Fixes for Mitaka Leapfrog

### DIFF
--- a/playbooks/patches/mitaka/haproxy-symlink-fix.patch
+++ b/playbooks/patches/mitaka/haproxy-symlink-fix.patch
@@ -1,0 +1,38 @@
+diff --git a/playbooks/roles/haproxy_server/tasks/haproxy_pre_install.yml b/playbooks/roles/haproxy_server/tasks/haproxy_pre_install.yml
+index adea9278..4f4b50eb 100644
+--- a/playbooks/roles/haproxy_server/tasks/haproxy_pre_install.yml
++++ b/playbooks/roles/haproxy_server/tasks/haproxy_pre_install.yml
+@@ -13,29 +13,13 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ 
+-- name: Test for log directory or link
+-  shell: |
+-    if [ -h "/var/log/haproxy"  ]; then
+-      chown -h syslog:adm "/var/log/haproxy"
+-      chown -R syslog:adm "$(readlink /var/log/haproxy)"
+-    else
+-      exit 1
+-    fi
+-  register: log_dir
+-  failed_when: false
+-  changed_when: log_dir.rc != 0
+-  tags:
+-    - haproxy-dirs
+-    - haproxy-logs
+-
+ - name: Create haproxy log dir
+   file:
+-    path: "{{ item.path }}"
++    path: "{{ '/var/log/haproxy' | realpath }}"
+     state: directory
+-    mode: "{{ item.mode|default('0755') }}"
+-  with_items:
+-    - { path: "/var/log/haproxy" }
+-  when: log_dir.rc != 0
++    owner: syslog
++    group: adm
++    mode: "0755"
+   tags:
+     - haproxy-dirs
+     - haproxy-logs

--- a/releasenotes/notes/add-mitaka-leapfrog-support-1b1cdfadb3ff53eb.yaml
+++ b/releasenotes/notes/add-mitaka-leapfrog-support-1b1cdfadb3ff53eb.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Adds Mitaka to Newton Leapfrog support to rpc-upgrades

--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -133,7 +133,7 @@ uname -a
 scp -r -o StrictHostKeyChecking=no /opt/rpc-openstack infra1:/opt/
 scp -r -o StrictHostKeyChecking=no /opt/rpc-upgrades infra1:/opt/
 scp -r -o StrictHostKeyChecking=no /etc/openstack_deploy/user_rpco_upgrade.yml infra1:/etc/openstack_deploy/
-
+scp -r -o StrictHostKeyChecking=no /etc/openstack_deploy/user_osa_variables_spice.yml infra1:/etc/openstack_deploy/
 # Put configs in place on Infra1 and gather release state
 ssh -T -o StrictHostKeyChecking=no infra1 << 'EOF'
 set -xe

--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -218,12 +218,14 @@ EOF
 }
 
 function correct_haproxy_logdir_symlink_patch {
-  apt-get install -y rsyslog
-  pushd /opt/rpc-openstack/openstack-ansible
-    if grep 'Test for log directory or link' /opt/rpc-openstack/openstack-ansible/playbooks/roles/haproxy_server/tasks/haproxy_pre_install.yml; then
-      patch -p1 < ${WORKSPACE_PATH}/playbooks/patches/liberty/haproxy-symlink-fix.patch
-    fi
-  popd
+  if [ "${RE_JOB_IMAGE_TYPE}" == "aio" ]; then
+    apt-get install -y rsyslog
+    pushd /opt/rpc-openstack/openstack-ansible
+      if grep 'Test for log directory or link' /opt/rpc-openstack/openstack-ansible/playbooks/roles/haproxy_server/tasks/haproxy_pre_install.yml; then
+        patch -p1 < ${WORKSPACE_PATH}/playbooks/patches/${RE_JOB_SERIES}/haproxy-symlink-fix.patch
+      fi
+    popd
+  fi
 }
 
 ## Main ----------------------------------------------------------------------
@@ -332,6 +334,7 @@ pushd /opt/rpc-openstack
     unset_affinity
     allow_frontloading_vars
     spice_repo_fix
+    correct_haproxy_logdir_symlink_patch
     restore_default_apt_sources
   elif [ "${RE_JOB_SERIES}" == "newton" ]; then
     git_checkout "newton"  # Last commit of Newton


### PR DESCRIPTION
FLEEK-61 Adds Mitaka to Newton Support in rpc-upgrades

This commit enables support for running a Mitaka
upgrade and contains support needed for running
Mitaka AIO and MNAIO gating jobs.  It contains the
following fixes:

- Skips the variable migration for Mitaka
- Removes user_osa_variables_defaults as existing
settings don't work in Newton and adds neccessary
variables back into file.
- Disables Ceilometer in AIO, swift breaks because
it depends on Ceilometer running.
- Sets haproxy fix to run on AIOs only, not MNAIOs
Looks like Mitaka gate was hitting this as well, so
this ports the patch over to Mitaka.
- Pushes updated SPICE url to MNAIO infra1
- Ensures openstack_release is set to rpc_release to
avoid venv_tags from getting set to newton-eol instead
of the latest RPC release version.
- Adds release note

Depends on https://review.openstack.org/#/c/575527/ which has merged.