### PR TITLE
FLEEK-125 Set setuptools to newton-eol

### DIFF
--- a/scripts/pre_leap.sh
+++ b/scripts/pre_leap.sh
@@ -41,11 +41,13 @@ if grep '^horizon_custom_uploads\:' /etc/openstack_deploy/user_variables.yml; th
 fi
 
 # RLM-682 versions past 2.5.2 break things
-echo "python-ldap==2.5.2" >> /opt/rpc-openstack/openstack-ansible/global-requirement-pins.txt
+if ! grep '^python-ldap==2.5.2' /opt/rpc-openstack/openstack-ansible/global-requirement-pins.txt
+  echo "python-ldap==2.5.2" >> /opt/rpc-openstack/openstack-ansible/global-requirement-pins.txt
+fi
 
-# FLEEK-125 six module exceptions on 34.1.0 so if we find this in pins, use the one set in mitaka-eol
-if grep '^setuptools==34.1.0' /opt/rpc-openstack/openstack-ansible/global-requirement-pins.txt; then
-  sed -i 's|^setuptools.*|setuptools==33.1.1|g' /opt/rpc-openstack/openstack-ansible/global-requirement-pins.txt
+# FLEEK-125 six module exceptions on 34.1.0 so if we find this in leapfrog upgrade requirements, use the one set in newton-eol
+if grep '^setuptools==34.1.0' /opt/rpc-leapfrog/openstack-ansible-ops/leap-upgrades/lib/upgrade-requirements.txt; then
+  sed -i 's|^setuptools.*|setuptools==33.1.1|g' /opt/rpc-leapfrog/openstack-ansible-ops/leap-upgrades/lib/upgrade-requirements.txt
 fi
 
 # RLM-1375 Skip certain hardening tags during leap


### PR DESCRIPTION
34.1.0 appears to have issues with the six module,
downgrading to setuptools==33.1.1 which is what newton-eol's
global requirements is set too.

Also checks if python-ldap exists and applies once in order
to avoid multiple entries on additional attempts.