### PR TITLE
Fix creation of RE_ENV file

### DIFF
--- a/gating/check/run
+++ b/gating/check/run
@@ -61,7 +61,11 @@ else
 fi
 
 # dump all RE_ vars to file so it can be sourced for MNAIO
-env | grep RE_ | sed 's/^/export /' > /opt/rpc-upgrades/RE_ENV
+> /opt/rpc-upgrades/RE_ENV
+env | grep RE_ | while read -r match; do
+  varName=$(echo ${match} | cut -d= -f1)
+  echo "export ${varName}='${!varName}'" >> /opt/rpc-upgrades/RE_ENV
+done
 
 if [ "${RE_JOB_ACTION}" != "tox-test" ]; then
   sudo -H --preserve-env ./run-bindep.sh


### PR DESCRIPTION
This change fixes the RE_ENV file so that the environment variables
defined have values that are quoted. So for example without this fix,
`export RE_FOO_BAR=foo bar` is added to the file and when exported that
gives `RE_FOO_BAR=foo`. With this change it would become `export
RE_FOO_BAR='foo bar'` which gives `RE_FOO_BAR=foo bar`.

JIRA: RE-1685