### PR TITLE
FLEEK-142 Use rcbops galera_server branch for Mitaka

### DIFF
--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -252,7 +252,7 @@ function get_latest_mitaka_roles {
   cat <<EOF >> ${OSA_PATH}/ansible-role-requirements.yml
 - name: galera_server
   scm: git
-  src: https://git.openstack.org/openstack/openstack-ansible-galera_server
+  src: https://github.com/rcbops/openstack-ansible-galera_server
   version: mitaka-eol
 EOF
 }


### PR DESCRIPTION
Uses rcbops galera_server branch as we needed to bump
percona-xtrabackup version for testing the initial Mitaka
deploy.  Without this version bump, Galera hangs during
cluster installation.