### PR TITLE
FLEEK-144 Add support for decryption of Vault files

### DIFF
--- a/releasenotes/notes/add-ansible-vault-support-6c64f901599431d4.yaml
+++ b/releasenotes/notes/add-ansible-vault-support-6c64f901599431d4.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Adds Ansible Vault support for decryption and encryption of
+    OpenStack secrets files during a leapfrog upgrade.  To enable
+    `export ANSIBLE_VAULT_PASSWORD_FILE=path_to_vault_pass_file`
+    before running a leapfrog.  The password files user_secrets.yml
+    user_osa_secrets.yml, and user_rpco_secrets.yml will all be
+    decrypted during the process if present and re-encrypted at the
+    end of the leapfrog.

--- a/tests/test-upgrade.sh
+++ b/tests/test-upgrade.sh
@@ -16,6 +16,11 @@
 
 set -evu
 
+export OS_DEPLOY_DIR="/etc/openstack_deploy"
+export VAULT_ENCRYPTED_FILES="user_secrets.yml
+                              user_osa_secrets.yml
+                              user_rpco_secrets.yml"
+
 export RPC_TARGET_CHECKOUT=${RE_JOB_UPGRADE_TO:-'newton'}
 if [[ ${RE_JOB_UPGRADE_TO} == "r14.current" ]]; then
   pushd /opt/rpc-openstack
@@ -25,6 +30,20 @@ if [[ ${RE_JOB_UPGRADE_TO} == "r14.current" ]]; then
     echo "Upgrading to latest release of ${RPC_TARGET_CHECKOUT} (Newton)..."
   popd
 fi
+
+
+# FLEEK-144 Simulate ansible vault encrypted password files
+export ANSIBLE_VAULT_PASSWORD_FILE=/root/.vault_pass.txt
+if [ ! -f /root/.vault_pass.txt ]; then
+  openssl rand -base64 64 > /root/.vault_pass.txt
+fi
+
+# encrypt before testing upgrades
+for FILENAME in ${VAULT_ENCRYPTED_FILES}; do
+  if [ -f ${OS_DEPLOY_DIR}/${FILENAME} ]; then
+    ansible-vault encrypt ${OS_DEPLOY_DIR}/${FILENAME} --vault-password-file ${ANSIBLE_VAULT_PASSWORD_FILE}
+  fi
+done
 
 if [ "${RE_JOB_UPGRADE_ACTION}" == "leap" ]; then
   tests/test-leapfrog.sh
@@ -39,3 +58,10 @@ else
   echo "RE_JOB_UPGRADE_ACTION '${RE_JOB_UPGRADE_ACTION}' is not supported."
   exit 99
 fi
+
+# FLEEK-144 Decrypt after upgrade testing to allow other gate jobs to function
+for FILENAME in ${VAULT_ENCRYPTED_FILES}; do
+  if [ -f ${OS_DEPLOY_DIR}/${FILENAME} ]; then
+    ansible-vault decrypt ${OS_DEPLOY_DIR}/${FILENAME} --vault-password-file ${ANSIBLE_VAULT_PASSWORD_FILE}
+  fi
+done


### PR DESCRIPTION
Adds support for decrypting secrets files during the leapfrog
process and reencrypting them at the end.

The process automatically removes the vault file.  To use,
ensure ANSIBLE_VAULT_PASSWORD_FILE is set to the location of the
Ansible Vault file.