### PR TITLE
ASC-564 Send test results to qtest in post

### DIFF
--- a/gating/check/post
+++ b/gating/check/post
@@ -12,12 +12,17 @@ set -o pipefail
 # outside of the CI environment.
 export RE_HOOK_ARTIFACT_DIR="${RE_HOOK_ARTIFACT_DIR:-/tmp/artifacts}"
 export RE_HOOK_RESULT_DIR="${RE_HOOK_RESULT_DIR:-/tmp/results}"
+export RE_JOB_TESTING_ACTION=`echo ${RE_JOB_ACTION} | awk -F'_' {'print $5'}`
 
 ## Functions -----------------------------------------------------------------
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
 source ${BASE_DIR}/scripts/functions.sh
 
 ## Main ----------------------------------------------------------------------
+
+if [ $RE_JOB_TESTING_ACTION == "system" ]; then
+  bash -c "$(readlink -f $(dirname ${0})/post_send_junit_to_qtest.sh)"
+fi
 
 echo "#### BEGIN LOG COLLECTION ###"
 

--- a/gating/check/post_send_junit_to_qtest.sh
+++ b/gating/check/post_send_junit_to_qtest.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+## Shell Opts ----------------------------------------------------------------
+
+set -x
+
+## Vars ----------------------------------------------------------------------
+
+export QTEST_API_TOKEN=$RPC_ASC_QTEST_API_TOKEN
+VENV_NAME="venv-qtest"
+PROJECT_ID="76551"
+
+## Functions -----------------------------------------------------------------
+export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
+source ${BASE_DIR}/scripts/functions.sh
+
+## Main ----------------------------------------------------------------------
+
+# Create virtualenv for <TOOL NAME>
+virtualenv --no-wheel "${VENV_NAME}"
+
+# Activate virtualenv
+source "${VENV_NAME}/bin/activate"
+
+VENV_PIP="${VENV_NAME}/bin/pip"
+
+# Install zigzag from PyPI
+${VENV_PIP} install rpc-zigzag
+
+# Search for xml files in RE_HOOK_RESULT_DIR
+xml_files=()
+while IFS=  read -r -d $'\0' FILE; do
+    xml_files+=("${FILE}")
+done < <(find $RE_HOOK_RESULT_DIR -type f -name 'molecule_test_results.xml' -print0)
+
+# Upload the files
+echo "Attempting upload of ${#xml_files[@]} XML files"
+printf '%s\n' "${xml_files[@]}"
+for i in "${xml_files[@]}"; do
+    # Use <TOOL NAME> to process and upload to qtest
+    if zigzag $i $PROJECT_ID; then
+        echo "Upload Success: $i"
+    else
+        echo "Upload Failure: $i"
+    fi
+done
+
+# exit is hardcoded since xml from tempest is known to to fail
+exit 0


### PR DESCRIPTION
This commit adds a script to upload molecule test result xml data to
qTest during the `post` stage of the gating pipeline.