### PR TITLE
Ensure failed release notes jobs return nonzero exit code

### DIFF
--- a/gating/generate_release_notes/generate_release_notes.sh
+++ b/gating/generate_release_notes/generate_release_notes.sh
@@ -1,6 +1,14 @@
-#!/bin/bash -xe
+#!/bin/bash -x
 
 # This script is run within a docker container to generate release notes.
 
 /generate_reno_report.sh $NEW_TAG reno_report.md
-cat reno_report.md > all_notes.md
+report_status=$?
+
+if [[ ${report_status} == 0 ]]; then
+	cat reno_report.md > all_notes.md
+else
+	cat reno_report.md.err
+fi
+
+exit ${report_status}

--- a/gating/generate_release_notes/generate_reno_report.sh
+++ b/gating/generate_release_notes/generate_reno_report.sh
@@ -7,28 +7,16 @@ rst_file=${out_file}.rst
 
 reno report --branch ${release} --version ${release} --no-show-source --output ${rst_file} &> ${err_file}
 return_code=$?
-cat $err_file
 
 if [[ ${return_code} != 0 ]]; then
   if grep -q "KeyError: '${release}'" ${err_file}; then
-    cat > ${out_file} << EOF
-Release Notes
-=============
-
-${release}
--------------
-
-### No release notes
-
-EOF
-    return_code=0
     echo "Warning: No new Reno release notes found, this can indicate an issue with the tag."
   else
     echo "Failure: Reno failed to generate the report."
   fi
 else
-  pandoc --from rst --to markdown_github < ${rst_file} > ${out_file}
-  echo "Success: New Reno release notes found."
+  pandoc --from rst --to markdown_github < ${rst_file} > ${out_file} 2> ${err_file}
+  return_code=$?
 fi
 
 exit ${return_code}


### PR DESCRIPTION
This will ensure that release notes failures percolate up to where Jenkins logs will actually record something. Combined with https://github.com/rcbops/rpc-gating/pull/981 , we should start to get a better idea of where and when things fail.

The next step should be to also capture the "why" things fail.  At this point that'd require exporting reno_report.md.err to somewhere that Jenkins will actually reveal in logs.  But any quick solution feels brittle and hacky.  I don't want to add to that just yet. 