### PR TITLE
FLEEK-155 Ensure apt is in a healthy state during preflight

### DIFF
--- a/playbooks/preflight-check.yml
+++ b/playbooks/preflight-check.yml
@@ -21,6 +21,14 @@
     - name: Ping check
       ping:
 
+- name: Ensure Apt is in a healthy state across all hosts and containers
+  hosts: "hosts:all_containers"
+  gather_facts: false
+  user: root
+  tasks:
+    - name: Ensure Apt is in a healthy state
+      shell: "dpkg -a --configure; apt install -y -f"
+
 - name: Openstack release check if exists 
   hosts: localhost
   gather_facts: false


### PR DESCRIPTION
Runs a dpkg -a --configure; apt install -y -f to ensure all
package installs across all containers and hosts are clean so
the upgrade process isn't hindered by package failures from
apt being in a half completed state.