### PR TITLE
RI-433 Ensure DEPLOY_MAAS is not ran

### DIFF
--- a/tests/create-aio.sh
+++ b/tests/create-aio.sh
@@ -51,7 +51,7 @@ echo "+---------------- AIO RELEASE AND KERNEL ---------------+"
 
 pushd /opt/rpc-openstack
   export DEPLOY_HAPROXY="yes"
-  export DEPLOY_MAAS="no"
+  export DEPLOY_MAAS="false"
   export DEPLOY_AIO="yes"
   export DEPLOY_HARDENING="yes"
   scripts/deploy.sh

--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -159,7 +159,7 @@ ${MNAIO_SSH} "source /opt/rpc-upgrades/RE_ENV; \
               source /opt/rpc-upgrades/tests/ansible-env.rc; \
               pushd /opt/rpc-openstack; \
               export DEPLOY_ELK=yes; \
-              export DEPLOY_MAAS=no; \
+              export DEPLOY_MAAS=false; \
               export DEPLOY_TELEGRAF=no; \
               export DEPLOY_INFLUX=no; \
               export DEPLOY_AIO=no; \


### PR DESCRIPTION
Switches to using false for DEPLOY_MAAS to
ensure MAAS is not installed during the deployment
phase of gating job.