### PR TITLE
WIP - RI-435 Gating fixes and optimizations

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ job_actions = [
   "kilo_to_newton_leap",
   "kilo_to_r14.16.0_leap",
   "liberty_to_newton_leap",
-  "mitaka_to_newton_major",
+  "mitaka_to_newton_leap",
   "r12.1.2_to_r14.16.0_leap",
   "r12.2.2_to_r14.16.0_leap",
   "r12.2.5_to_r14.16.0_leap",

--- a/playbooks/prepare-ocata-upgrade.yml
+++ b/playbooks/prepare-ocata-upgrade.yml
@@ -32,8 +32,11 @@
 
     - name: Remove existing artifact repos
       file:
-        path: /etc/apt/sources.list.d/rpco.list
+        path: "{{ item }}"
         state: absent
+      with_items:
+        - /etc/apt/sources.list.d/rpco.list
+        - /etc/apt/sources.list.d/rax-maas.list
 
     - name: Update apt-cache
       apt:

--- a/scripts/ubuntu16-ocata-to-pike.sh
+++ b/scripts/ubuntu16-ocata-to-pike.sh
@@ -18,7 +18,7 @@ set -evu
 
 export RPC_BRANCH=${RPC_BRANCH:-'r16.1.0'}
 export OSA_SHA="stable/pike"
-export SKIP_INSTALL=${SKIP_INSTALL:-'yes'}
+export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
 
 function strip_install_steps {
   pushd /opt/openstack-ansible/scripts

--- a/scripts/ubuntu16-pike-to-queens.sh
+++ b/scripts/ubuntu16-pike-to-queens.sh
@@ -16,7 +16,7 @@
 
 set -evu
 
-export RPC_BRANCH=${RPC_BRANCH:-'master'}
+export RPC_BRANCH=${RPC_BRANCH:-'r17.0.1'}
 export OSA_SHA="stable/queens"
 
 pushd /opt/rpc-openstack

--- a/tests/maas-install.sh
+++ b/tests/maas-install.sh
@@ -21,7 +21,8 @@ set -evu
 ## Vars ----------------------------------------------------------------------
 export RE_JOB_SERIES="${RE_JOB_SERIES:-newton}"
 export RPCO_RELEASE=`cat /etc/openstack-release | grep DISTRIB_CODENAME | cut -d '"' -f2`
-export RPC_MAAS_RELEASE=23085d0b08043cf6185204302eaee1e90188b288
+export RPC_MAAS_RELEASE=1.7.4
+export SKIP_MAAS_PREFLIGHT="-e maas_pre_flight_metadata_check_enabled=false"
 
 ## Main ----------------------------------------------------------------------
 # workaround for kilos incorrect code name
@@ -36,9 +37,9 @@ pushd /opt/rpc-upgrades/playbooks
   # install rpc-maas
   # if kilo and hasn't leaped, use a different swift_recon_path since kilo doesn't use venvs
   if [[ ${RE_JOB_SERIES} == "kilo" && ! -f /etc/openstack_deploy/upgrade-leap/osa-leap.complete ]]; then
-    openstack-ansible /opt/rpc-maas/playbooks/site.yml -e swift_recon_path="/usr/local/bin/" -vv
+    openstack-ansible /opt/rpc-maas/playbooks/site.yml -vv -e swift_recon_path="/usr/local/bin/" ${SKIP_MAAS_PREFLIGHT}
   else
-   openstack-ansible /opt/rpc-maas/playbooks/site.yml -vv
+   openstack-ansible /opt/rpc-maas/playbooks/site.yml -vv ${SKIP_MAAS_PREFLIGHT}
   fi
 
   # verify rpc-maas if leap has completed

--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -19,7 +19,7 @@
 
 set -evu
 
-echo "Building an AIO"
+echo "Prepare RPC-O AIO/MNAIO deploy"
 echo "+-------------------- AIO ENV VARS --------------------+"
 env
 echo "+-------------------- AIO ENV VARS --------------------+"
@@ -377,6 +377,15 @@ pushd /opt/rpc-openstack
     pin_galera "10.0"
     unset_affinity
     allow_frontloading_vars
+  elif [ "${RE_JOB_SERIES}" == "ocata" ]; then
+    git_checkout "ocata"  # Last commit of Ocata
+    (git submodule init && git submodule update) || true
+  elif [ "${RE_JOB_SERIES}" == "pike" ]; then
+    git_checkout "pike"  # Last commit of Pike
+    (git submodule init && git submodule update) || true
+  elif [ "${RE_JOB_SERIES}" == "queens" ]; then
+    git_checkout "queens"  # Last commit of Queens
+    (git submodule init && git submodule update) || true
   else
     if ! git_checkout ${RE_JOB_SERIES}; then
       echo "FAIL!"


### PR DESCRIPTION
RI-435 Gating fixes and optimizations

* Installs ara package and callbacks on incremental upgrades, not
  used for Newton and older because Ansible versions are too old.
  This should let us start gathering metrics from upgrades from
  Newton.
* Drops OSA_BRANCH variable since it's not used
* Add SERIES checks for newer releases to account for the releases
  and give us a place for future modifications if needed.
* Only pushes updated spice-html5 url fixes if needed
* Set MNAIO guest OS based on RE_JOB_IMAGE_OS
* Clean out ansible roles on infra1 before deploy
* Correct RPC-O version checked out on queens upgrade
* Flip vagrant mitaka to leap from major
* Add logic for setting up MNAIO config files since source locations
  change in RPC-O post Newton
* Disable skip install during O2P as migrations are skipped
* Bump MaaS testing to latest 1.7.4 release
* Disable maas_pre_flight_metadata_check_enabled