### PR TITLE
RI-466 Remove ansible_facts to clean old facts out

### DIFF
--- a/scripts/ubuntu16-pike-to-queens.sh
+++ b/scripts/ubuntu16-pike-to-queens.sh
@@ -48,3 +48,6 @@ pushd /opt/openstack-ansible
   cp /opt/rpc-upgrades/scripts/run-upgrade/queens/run-upgrade.sh scripts/run-upgrade.sh
   echo "YES" | bash scripts/run-upgrade.sh
 popd
+
+# remove ansible_facts cache to reflect cleanup of containers at end of upgrade
+rm -rf /etc/openstack_deploy/ansible_facts/*


### PR DESCRIPTION
Old facts remain after the inventory has been updated.
This removes the facts and forces a rebuild of them the
next time a run happens.