### PR TITLE
RI-466 Cleanup Queens inventory after upgrade

### DIFF
--- a/playbooks/cleanup-queens-inventory.yml
+++ b/playbooks/cleanup-queens-inventory.yml
@@ -1,0 +1,38 @@
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- hosts: localhost
+  connection: local
+  become: yes
+  gather_facts: no
+  tasks:
+    - name: Remove the inventory entries for the deleted containers
+      command: >-
+        /opt/openstack-ansible/scripts/inventory-manage.py -r {{ item }}
+      with_items: "{{ groups['nova_api_metadata_container'] +
+                      groups['nova_api_os_compute_container'] +
+                      groups['nova_api_placement_container'] +
+                      groups['nova_conductor_container'] +
+                      groups['nova_console_container'] +
+                      groups['nova_scheduler_container'] +
+                      groups['cinder_scheduler_container'] +
+                      groups['heat_apis_container'] +
+                      groups['heat_engine_container'] +
+                      groups['ironic_conductor_container'] +
+                      groups['trove_conductor_container'] +
+                      groups['trove_taskmanager_container'] }}"
+    - name: Remove ansible_facts to clear cache
+      file:
+        state: absent
+        path: "/etc/openstack_deploy/ansible_facts/"

--- a/scripts/ubuntu16-pike-to-queens.sh
+++ b/scripts/ubuntu16-pike-to-queens.sh
@@ -49,5 +49,7 @@ pushd /opt/openstack-ansible
   echo "YES" | bash scripts/run-upgrade.sh
 popd
 
-# remove ansible_facts cache to reflect cleanup of containers at end of upgrade
-rm -rf /etc/openstack_deploy/ansible_facts/*
+# ensure inventory is cleaned up from old containers and reset ansible_facts cache
+pushd /opt/rpc-upgrades/playbooks
+  openstack-ansible cleanup-queens-inventory.yml
+popd


### PR DESCRIPTION
It appears that the inventory isn't getting properly cleaned up
by the upgrade cleanup scripts, so we do one more pass to ensure
old inventory is removed and reset the ansible_facts cache to
ensure no old cruft is hanging around