### PR TITLE
Drop the older versions required

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,7 +6,7 @@ flake8<2.6.0,>=2.5.4 # MIT
 pyasn1 # BSD
 pyOpenSSL>=0.14 # Apache-2.0
 pycrypto<=2.6.1
-requests!=2.12.2,!=2.13.0,>=2.20.0 # Apache-2.0
+requests>=2.20.0
 ndg-httpsclient>=0.4.2;python_version<'3.0' # BSD
 
 # this is required for the docs build jobs


### PR DESCRIPTION
With the version bump, don't need the exclusions anymore.