### PR TITLE
Only run functions if available, run ARA log collection

### DIFF
--- a/gating/check/post
+++ b/gating/check/post
@@ -19,7 +19,9 @@ export RE_JOB_TESTING_ACTION=`echo ${RE_JOB_ACTION} | awk -F'_' {'print $5'}`
 
 ## Functions -----------------------------------------------------------------
 export BASE_DIR=${BASE_DIR:-"/opt/rpc-openstack"}
-source ${BASE_DIR}/scripts/functions.sh
+if [ -f ${BASE_DIR}/scripts/functions.sh ]; then
+  source ${BASE_DIR}/scripts/functions.sh
+fi
 
 ## Main ----------------------------------------------------------------------
 
@@ -28,6 +30,13 @@ if [ $RE_JOB_TESTING_ACTION == "system" ]; then
 fi
 
 echo "#### BEGIN LOG COLLECTION ###"
+
+# if ARA is installed and supported, generate ara html logs
+ARA_CMD="/opt/ansible-runtime/bin/ara"
+if [ -f ${ARA_CMD} ]; then
+  mkdir -p ${RE_HOOK_RESULT_DIR}/ara
+  ${ARA_CMD} generate html ${RE_HOOK_RESULT_DIR}/ara/
+fi
 
 collect_logs_cmd="ansible-playbook"
 collect_logs_cmd+=" --ssh-common-args='-o StrictHostKeyChecking=no'"


### PR DESCRIPTION
Adds a check to load functions if available, so it doesn't
break on versions that don't have that file (older)

Also adds a check to run ARA if the binary is detected.  Older
versions did not support ARA, so if the binary isn't present, it
will skip ARA collection.