### PR TITLE
Uses vars from rpc-openstack for upgrades

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -120,6 +120,26 @@ function checkout_openstack_ansible {
   fi
 }
 
+function configure_rpc_openstack {
+  rsync -av --delete /opt/rpc-openstack/etc/openstack_deploy/group_vars /etc/openstack_deploy/
+  rm -rf /opt/rpc-ansible
+  virtualenv /opt/rpc-ansible
+  install_ansible_source
+  pushd /opt/rpc-openstack/playbooks
+    /opt/rpc-ansible/bin/ansible-playbook -i 'localhost,' site-release.yml
+  popd
+}
+
+function install_ansible_source {
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+                                            gcc libssl-dev libffi-dev \
+                                            python-apt python3-apt \
+                                            python-dev python3-dev \
+                                            python-minimal python-virtualenv
+
+  /opt/rpc-ansible/bin/pip install --isolated "ansible==${RPC_ANSIBLE_VERSION}"
+}
+
 function set_keystone_flush_memcache {
   if [[ ! -f /etc/openstack_deploy/user_rpco_upgrade.yml ]]; then
      echo "---" > /etc/openstack_deploy/user_rpco_upgrade.yml
@@ -159,6 +179,7 @@ function run_upgrade {
     export TERM=linux
     export I_REALLY_KNOW_WHAT_I_AM_DOING=true
     export SETUP_ARA=true
+    export ANSIBLE_CALLBACK_PLUGINS=/etc/ansible/roles/plugins/callback:/opt/ansible-runtime/local/lib/python2.7/site-packages/ara/plugins/callbacks
     echo "YES" | bash scripts/run-upgrade.sh
   popd
 }

--- a/incremental/ubuntu16-upgrade-to-pike.sh
+++ b/incremental/ubuntu16-upgrade-to-pike.sh
@@ -18,14 +18,17 @@ set -evu
 
 source lib/functions.sh
 
-export RPC_BRANCH=${RPC_BRANCH:-'r16.2.4'}
+#export RPC_BRANCH=${RPC_BRANCH:-'r16.2.6'}
+export RPC_BRANCH=${RPC_BRANCH:-'pike'}
 export OSA_SHA="stable/pike"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
+export RPC_PRODUCT_RELEASE="pike"
+export RPC_ANSIBLE_VERSION="2.3.2.0"
 
 echo "Starting Ocata to Pike Upgrade..."
 
 checkout_rpc_openstack
-checkout_openstack_ansible
+configure_rpc_openstack
 disable_hardening
 set_keystone_flush_memcache
 prepare_pike

--- a/incremental/ubuntu16-upgrade-to-queens.sh
+++ b/incremental/ubuntu16-upgrade-to-queens.sh
@@ -18,14 +18,17 @@ set -evu
 
 source lib/functions.sh
 
-export RPC_BRANCH=${RPC_BRANCH:-'r17.1.1'}
+#export RPC_BRANCH=${RPC_BRANCH:-'r17.1.2'}
+export RPC_BRANCH=${RPC_BRANCH:-'queens'}
 export OSA_SHA="stable/queens"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
+export RPC_PRODUCT_RELEASE="queens"
+export RPC_ANSIBLE_VERSION="2.4.3.0"
 
 echo "Starting Pike to Queens Upgrade..."
 
 checkout_rpc_openstack
-checkout_openstack_ansible
+configure_rpc_openstack
 set_secrets_file
 disable_hardening
 prepare_queens

--- a/incremental/ubuntu16-upgrade-to-rocky.sh
+++ b/incremental/ubuntu16-upgrade-to-rocky.sh
@@ -21,11 +21,13 @@ source lib/functions.sh
 export RPC_BRANCH=${RPC_BRANCH:-'rocky'}
 export OSA_SHA="stable/rocky"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
+export RPC_PRODUCT_RELEASE="rocky"
+export RPC_ANSIBLE_VERSION="2.5.5"
 
 echo "Starting Queens to Rocky Upgrade..."
 
 checkout_rpc_openstack
-checkout_openstack_ansible
+configure_rpc_openstack
 set_secrets_file
 disable_hardening
 bootstrap_ansible


### PR DESCRIPTION
Syncs group_vars and runs the site-release playbook
from rpc-openstack to ensure the proper variables for
a supported release are used during an upgrade.

This ensures the proper RPC release version numbers are set
and that any overrides we've made to the release are used
during the upgrade.