### PR TITLE
Shorten incremental action name

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -24,7 +24,9 @@ job_actions = [
   "r12.2.2_to_r14.20.0_leap",
   "r12.2.5_to_r14.20.0_leap",
   "r12.2.8_to_r14.20.0_leap",
-  "newton_to_queens_incremental",
+  "newton_to_queens_inc",
+  "pike_to_queens_inc",
+  "queens_to_rocky_inc"
 ]
 
 Vagrant.configure("2") do |config|

--- a/gating/check/run
+++ b/gating/check/run
@@ -102,7 +102,7 @@ function run_mnaio_upgrade {
 }
 
 function post_upgrade {
-  if [ "${RE_JOB_UPGRADE_ACTION}" != "incremental" ]; then
+  if [ "${RE_JOB_UPGRADE_ACTION}" != "inc" ]; then
     #sudo -H --preserve-env ./tests/maas-install.sh
     sudo -H --preserve-env ./tests/qc-test.sh
     # RLM-292 secondary test-upgrade run to validate idempotency

--- a/testing.rst
+++ b/testing.rst
@@ -79,7 +79,7 @@ these variables:
 
 .. code-block:: shell
 
-    export RE_JOB_ACTION="newton_to_queens_incremental"
+    export RE_JOB_ACTION="newton_to_queens_inc"
     export RE_JOB_IMAGE="xenial_mnaio"
     ./run-tests.sh
 
@@ -88,7 +88,7 @@ already has the version to be upgraded from deployed, then use:
 
 .. code-block:: shell
 
-    export RE_JOB_ACTION="newton_to_queens_incremental"
+    export RE_JOB_ACTION="newton_to_queens_inc"
     export RE_JOB_IMAGE="xenial_mnaio-snap"
     ./run-tests.sh
 

--- a/tests/test-upgrade.sh
+++ b/tests/test-upgrade.sh
@@ -37,7 +37,7 @@ elif [ "${RE_JOB_UPGRADE_ACTION}" == "major" ]; then
   tests/test-major.sh
 elif [ "${RE_JOB_UPGRADE_ACTION}" == "minor" ]; then
   tests/test-minor.sh
-elif [ "${RE_JOB_UPGRADE_ACTION}" == "incremental" ] ; then
+elif [ "${RE_JOB_UPGRADE_ACTION}" == "inc" ] ; then
   tests/test-incremental.sh
 else
   echo "FAIL!"

--- a/tests/upgrade-mnaio.sh
+++ b/tests/upgrade-mnaio.sh
@@ -27,7 +27,7 @@ echo "+-------------------- MNAIO ENV VARS --------------------+"
 export MNAIO_SSH="ssh -ttt -oStrictHostKeyChecking=no root@infra1"
 
 # upgrade mnaio vms from trusty to xenial if testing incremental
-if [[ "${RE_JOB_UPGRADE_ACTION}" == "incremental" && ${RE_JOB_IMAGE_OS} == "trusty" && ${RE_JOB_IMAGE_TYPE} == "mnaio" ]] ; then
+if [[ "${RE_JOB_UPGRADE_ACTION}" == "inc" && ${RE_JOB_IMAGE_OS} == "trusty" && ${RE_JOB_IMAGE_TYPE} == "mnaio" ]] ; then
   push /opt/rpc-upgrades/playbooks
     openstack-ansible mnaio-trusty-to-xenial.yml
   popd


### PR DESCRIPTION
In order to save space on gating job names, this shortens
incremental to inc.

Depends on https://github.com/rcbops/rpc-gating/pull/1228