### PR TITLE
[RI-596] Require Ubuntu 16 for incremental upgrades

### DIFF
--- a/incremental/incremental-upgrade.sh
+++ b/incremental/incremental-upgrade.sh
@@ -20,6 +20,7 @@ source lib/functions.sh
 source lib/vars.sh
 
 discover_code_version
+require_ubuntu_version 16
 
 # if target not set, exit and inform user how to proceed
 if [[ -z "$1" ]]; then

--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -46,6 +46,15 @@ function discover_code_version {
     fi
 }
 
+# Fail if Ubuntu Major release is not the minimum required for a given OpenStack upgrade
+function require_ubuntu_version {
+  REQUIRED_VERSION="$1"
+  if [ "$(lsb_release -r | cut -f2 -d$'\t' | cut -f1 -d$'.')" -lt "$REQUIRED_VERSION" ]; then
+    echo "Please upgrade to Ubuntu "$REQUIRED_VERSION" before attempting to upgrade OpenStack"
+    exit 99
+  fi
+}
+
 function pre_flight {
     ## Pre-flight Check ----------------------------------------------------------
     # Clear the screen and make sure the user understands whats happening.

--- a/incremental/ubuntu16-upgrade-to-ocata.sh
+++ b/incremental/ubuntu16-upgrade-to-ocata.sh
@@ -18,6 +18,8 @@ set -evu
 
 source lib/functions.sh
 
+require_ubuntu_version 16
+
 export RPC_BRANCH=${RPC_BRANCH:-'ocata'}
 export OSA_SHA="stable/ocata"
 export SKIP_INSTALL=${SKIP_INSTALL:-"yes"}

--- a/incremental/ubuntu16-upgrade-to-pike.sh
+++ b/incremental/ubuntu16-upgrade-to-pike.sh
@@ -18,6 +18,8 @@ set -evu
 
 source lib/functions.sh
 
+require_ubuntu_version 16
+
 #export RPC_BRANCH=${RPC_BRANCH:-'r16.2.6'}
 export RPC_BRANCH=${RPC_BRANCH:-'pike'}
 export OSA_SHA="stable/pike"

--- a/incremental/ubuntu16-upgrade-to-queens.sh
+++ b/incremental/ubuntu16-upgrade-to-queens.sh
@@ -18,6 +18,8 @@ set -evu
 
 source lib/functions.sh
 
+require_ubuntu_version 16
+
 #export RPC_BRANCH=${RPC_BRANCH:-'r17.1.2'}
 export RPC_BRANCH=${RPC_BRANCH:-'queens'}
 export OSA_SHA="stable/queens"

--- a/incremental/ubuntu16-upgrade-to-rocky.sh
+++ b/incremental/ubuntu16-upgrade-to-rocky.sh
@@ -18,6 +18,8 @@ set -evu
 
 source lib/functions.sh
 
+require_ubuntu_version 16
+
 export RPC_BRANCH=${RPC_BRANCH:-'rocky'}
 export OSA_SHA="stable/rocky"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}


### PR DESCRIPTION
This should prevent incremental upgrades from getting too far in out-of-date Ubuntu environments.