### PR TITLE
Remove secrets relink and leverage the secrets variable

### DIFF
--- a/incremental/playbooks/prepare-ocata-upgrade.yml
+++ b/incremental/playbooks/prepare-ocata-upgrade.yml
@@ -63,17 +63,6 @@
   hosts: localhost
   user: root
   tasks:
-    - name: Ensure user_secrets.yml is not present
-      file:
-        path: /etc/openstack_deploy/user_secrets.yml
-        state: absent
-
-    - name: Create symlink of user_osa_secrets.yml to user_secrets.yml
-      file:
-        src: /etc/openstack_deploy/user_osa_secrets.yml
-        dest: /etc/openstack_deploy/user_secrets.yml
-        state: link
-
     - name: Remove user_rpco_variables_defaults.yml for newton
       file:
         path: /etc/openstack_deploy/user_rpco_variables_defaults.yml

--- a/incremental/ubuntu16-upgrade-to-ocata.sh
+++ b/incremental/ubuntu16-upgrade-to-ocata.sh
@@ -32,6 +32,7 @@ prepare_ocata
 
 checkout_rpc_openstack
 checkout_openstack_ansible
+set_secrets_file
 disable_hardening
 set_keystone_flush_memcache
 

--- a/incremental/ubuntu16-upgrade-to-pike.sh
+++ b/incremental/ubuntu16-upgrade-to-pike.sh
@@ -29,6 +29,7 @@ echo "Starting Ocata to Pike Upgrade..."
 
 checkout_rpc_openstack
 checkout_openstack_ansible
+set_secrets_file
 disable_hardening
 set_keystone_flush_memcache
 prepare_pike


### PR DESCRIPTION
Removes some tasks to symlink the secrets files and uses
the secrets function instead to set the secrets file to
the file that is present.