### PR TITLE
Allow Ocata package update to be skipped

### DIFF
--- a/incremental/playbooks/prepare-ocata-upgrade.yml
+++ b/incremental/playbooks/prepare-ocata-upgrade.yml
@@ -16,6 +16,7 @@
 - name: Set Repos and Update to latest Xenial Packages
   hosts: hosts:all_containers
   user: root
+  when: "{{ update_xenial_packages | default(true) }}"
   tasks:
     - name: Backup the original sources file
       copy:


### PR DESCRIPTION
Occasionally, the pre-update of Xenial packages breaks
either due to transient time out issues or ansible version
quirks.  This flag allows the operator to skip the update, if
it is deemed unnecessary.