### PR TITLE
[RI-621] Only prep Ocata once at most

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -204,9 +204,11 @@ function strip_install_steps {
 }
 
 function prepare_ocata {
-  pushd /opt/rpc-upgrades/incremental/playbooks
-    openstack-ansible prepare-ocata-upgrade.yml
-  popd
+  if [[ ! -f "/etc/openstack_deploy/ocata_upgrade_prep.complete" ]]; then
+    pushd /opt/rpc-upgrades/incremental/playbooks
+      openstack-ansible prepare-ocata-upgrade.yml
+    popd
+  fi
 }
 
 function prepare_pike {

--- a/incremental/playbooks/prepare-ocata-upgrade.yml
+++ b/incremental/playbooks/prepare-ocata-upgrade.yml
@@ -38,16 +38,6 @@
         - /etc/apt/sources.list.d/rpco.list
         - /etc/apt/sources.list.d/rax-maas.list
 
-    - name: Update all packages to the latest version
-      apt:
-        upgrade: dist
-        update_cache: yes
-        cache_valid_time: 1200
-      register: update_packages
-      until: update_packages is success
-      retries: 5
-      delay: 2
-
 - name: Ensure artifact repos removed from containers
   hosts: "hosts:all_containers"
   user: root
@@ -106,3 +96,9 @@
         - /etc/openstack_deploy/env.d
         - /etc/openstack_deploy/ansible_facts
         - /etc/openstack_deploy/user_osa_variables_defaults.yml
+
+    - name: Set lock file
+      file:
+        path: /etc/openstack_deploy/ocata_upgrade_prep.complete
+        state: touch
+        mode: 0644


### PR DESCRIPTION
Also allows manual override by operator.
The reason for this is to avoid issues with failed reruns,
sometimes manifesting as template failures.  It also saves some
time on reruns.