### PR TITLE
[RI-620] (WIP) Add an optional play to disable IPv6 on containers

### DIFF
--- a/incremental/playbooks/force_ipv4.yml
+++ b/incremental/playbooks/force_ipv4.yml
@@ -1,0 +1,38 @@
+---
+# Copyright 2018, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+- name: Force containers to use IPv4
+  hosts: hosts:all_containers
+  user: root
+  tasks:
+    - lineinfile:
+        path: /etc/sysctl.d/99-sysctl.conf
+        regexp: '^net.ipv6.conf.all.disable_ipv6'
+        state: present
+        line: "net.ipv6.conf.all.disable_ipv6 = 1"
+    - lineinfile:
+        path: /etc/sysctl.d/99-sysctl.conf
+        regexp: '^ net.ipv6.conf.default.disable_ipv6'
+        state: present
+        line: "net.ipv6.conf.default.disable_ipv6 = 1"
+    - lineinfile:
+        path: /etc/sysctl.d/99-sysctl.conf
+        regexp: '^net.ipv6.conf.lo.disable_ipv6'
+        state: present
+        line: "net.ipv6.conf.lo.disable_ipv6 = 1"
+    - name: Restart sysctl
+      shell: "sudo systctl -p"
+  when: "{{ upgrade_disable_ipv6 | default('false') }}"


### PR DESCRIPTION
As per RI-620, we ran into an issue where containers were using ipv6 interfaces and failing to install packages as a result.  This pull aims to allow operators to disable IPv6 for containers, if they deem it necessary.