### PR TITLE
RI-630 Push rpc-openstack from host to infra1

### DIFF
--- a/tests/create-mnaio-snap.sh
+++ b/tests/create-mnaio-snap.sh
@@ -127,6 +127,7 @@ lsb_release -a
 uname -a
 echo "+---------------- MNAIO RELEASE AND KERNEL --------------+"
 scp -r -o StrictHostKeyChecking=no /opt/rpc-upgrades infra1:/opt/
+scp -r -o StrictHostKeyChecking=no /opt/rpc-openstack infra1:/opt/
 scp -r -o StrictHostKeyChecking=no /etc/openstack_deploy/user_rpco_upgrade.yml infra1:/etc/openstack_deploy/
 if [ -f /etc/openstack_deploy/user_osa_variables_spice.yml ]; then
   scp -r -o StrictHostKeyChecking=no /etc/openstack_deploy/user_osa_variables_spice.yml infra1:/etc/openstack_deploy/


### PR DESCRIPTION
Ensures the rpc-o repo on infra1 from the image snapshot
is overridden with a fresh repo that doesn't utilize ssh
repo.