### PR TITLE
Uses vars from rpc-openstack for upgrades

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -129,6 +129,28 @@ function checkout_openstack_ansible {
   fi
 }
 
+function configure_rpc_openstack {
+  rsync -av --delete /opt/rpc-openstack/etc/openstack_deploy/group_vars /etc/openstack_deploy/
+  rm -rf /opt/rpc-ansible
+  virtualenv /opt/rpc-ansible
+  install_ansible_source
+  pushd /opt/rpc-openstack/playbooks
+    /opt/rpc-ansible/bin/ansible-playbook -i 'localhost,' site-release.yml
+  popd
+  # clean out any existing env.d inventory
+  rm /etc/openstack_deploy/env.d/*
+}
+
+function install_ansible_source {
+  DEBIAN_FRONTEND=noninteractive apt-get -y install \
+                                            gcc libssl-dev libffi-dev \
+                                            python-apt python3-apt \
+                                            python-dev python3-dev \
+                                            python-minimal python-virtualenv
+
+  /opt/rpc-ansible/bin/pip install --isolated "ansible==${RPC_ANSIBLE_VERSION}"
+}
+
 function set_keystone_flush_memcache {
   if [[ ! -f /etc/openstack_deploy/user_rpco_upgrade.yml ]]; then
      echo "---" > /etc/openstack_deploy/user_rpco_upgrade.yml

--- a/incremental/ubuntu16-upgrade-to-pike.sh
+++ b/incremental/ubuntu16-upgrade-to-pike.sh
@@ -24,11 +24,13 @@ require_ubuntu_version 16
 export RPC_BRANCH=${RPC_BRANCH:-'pike'}
 export OSA_SHA="stable/pike"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
+export RPC_PRODUCT_RELEASE="pike"
+export RPC_ANSIBLE_VERSION="2.3.2.0"
 
 echo "Starting Ocata to Pike Upgrade..."
 
 checkout_rpc_openstack
-checkout_openstack_ansible
+configure_rpc_openstack
 set_secrets_file
 disable_hardening
 set_keystone_flush_memcache

--- a/incremental/ubuntu16-upgrade-to-queens.sh
+++ b/incremental/ubuntu16-upgrade-to-queens.sh
@@ -24,11 +24,13 @@ require_ubuntu_version 16
 export RPC_BRANCH=${RPC_BRANCH:-'queens'}
 export OSA_SHA="stable/queens"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
+export RPC_PRODUCT_RELEASE="queens"
+export RPC_ANSIBLE_VERSION="2.4.3.0"
 
 echo "Starting Pike to Queens Upgrade..."
 
 checkout_rpc_openstack
-checkout_openstack_ansible
+configure_rpc_openstack
 set_secrets_file
 disable_hardening
 prepare_queens

--- a/incremental/ubuntu16-upgrade-to-rocky.sh
+++ b/incremental/ubuntu16-upgrade-to-rocky.sh
@@ -23,11 +23,13 @@ require_ubuntu_version 16
 export RPC_BRANCH=${RPC_BRANCH:-'rocky'}
 export OSA_SHA="stable/rocky"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
+export RPC_PRODUCT_RELEASE="rocky"
+export RPC_ANSIBLE_VERSION="2.5.5"
 
 echo "Starting Queens to Rocky Upgrade..."
 
 checkout_rpc_openstack
-checkout_openstack_ansible
+configure_rpc_openstack
 set_secrets_file
 disable_hardening
 prepare_rocky


### PR DESCRIPTION
Syncs group_vars and runs the site-release playbook
from rpc-openstack to ensure the proper variables for
a supported release are used during an upgrade.

This ensures the proper RPC release version numbers are set
and that any overrides we've made to the release are used
during the upgrade.