### PR TITLE
Exclude CEPH nodes from certain pre upgrade tasks

### DIFF
--- a/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
+++ b/playbooks/roles/rpc_pre_upgrade/tasks/log_rotation.yml
@@ -18,6 +18,9 @@
   register: large_logs
   delegate_to: "{{ item }}"
   with_items: "{{ groups['hosts'] }}"
+  when:
+    - (groups['mons_hosts'] is undefined or item not in groups['mons_hosts'])
+    - (groups['cephrgwdummy_hosts'] is undefined or item not in groups['cephrgwdummy_hosts'])
 
 - name: Compressed logs
   debug: var=large_logs.stdout_lines

--- a/playbooks/roles/rpc_pre_upgrade/tasks/main.yml
+++ b/playbooks/roles/rpc_pre_upgrade/tasks/main.yml
@@ -19,6 +19,7 @@
 
 # Backup database/repository/vars_files
 - include: backup.yml
+  tags: backup-configuration
 
 # Gather info on:
 # OpenStack service status
@@ -26,6 +27,7 @@
 # Running instances
 # Volume mappings
 - include: gather_stats.yml
+  tags: gather-stats
 
 # Gather swift-recon md5 output
 - include: gather_swift_stats.yml
@@ -33,5 +35,6 @@
 
 # Perform log rotation and cleanup
 - include: log_rotation.yml
+  tags: rotate-logs
 
 - include: enable_maas_holland.yml


### PR DESCRIPTION
The groups mons_hosts and cephrgwdummy_hosts are excluded
from the pre certain upgrade tasks as these nodes
are managed by ceph-ansible rather then OSA

Closes-Bug: Fleek-260