### PR TITLE
Sets released versions for RPC-O Pike/Queens

### DIFF
--- a/incremental/ubuntu16-upgrade-to-pike.sh
+++ b/incremental/ubuntu16-upgrade-to-pike.sh
@@ -20,8 +20,7 @@ source lib/functions.sh
 
 require_ubuntu_version 16
 
-#export RPC_BRANCH=${RPC_BRANCH:-'r16.2.6'}
-export RPC_BRANCH=${RPC_BRANCH:-'pike'}
+export RPC_BRANCH=${RPC_BRANCH:-'r16.2.9'}
 export OSA_SHA="stable/pike"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
 export RPC_PRODUCT_RELEASE="pike"

--- a/incremental/ubuntu16-upgrade-to-queens.sh
+++ b/incremental/ubuntu16-upgrade-to-queens.sh
@@ -20,8 +20,7 @@ source lib/functions.sh
 
 require_ubuntu_version 16
 
-#export RPC_BRANCH=${RPC_BRANCH:-'r17.1.2'}
-export RPC_BRANCH=${RPC_BRANCH:-'queens'}
+export RPC_BRANCH=${RPC_BRANCH:-'r17.1.4'}
 export OSA_SHA="stable/queens"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
 export RPC_PRODUCT_RELEASE="queens"


### PR DESCRIPTION
To limit unexpected change, lock increments to
stable release branches of Pike and Queens.