### PR TITLE
Bump Newton Leapfrogs to use r14.23.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,9 +27,9 @@ rpc-upgrades repo supports:
 
 Leapfrog upgrades from:
 
-* kilo to r14.21.0 (newton)
-* liberty to r14.21.0 (newton)
-* mitaka to r14.21.0 (newton)
+* kilo to r14.23.0 (newton)
+* liberty to r14.23.0 (newton)
+* mitaka to r14.23.0 (newton)
 
 Full docs for Leapfrog upgrades are `here <leapfrog.rst>`_.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,13 +17,13 @@ end
 # Configure Job Actions the way gating would pass them
 job_actions = [
   "kilo_to_newton_leap",
-  "kilo_to_r14.21.0_leap",
+  "kilo_to_r14.23.0_leap",
   "liberty_to_newton_leap",
   "mitaka_to_newton_leap",
-  "r12.1.2_to_r14.21.0_leap",
-  "r12.2.2_to_r14.21.0_leap",
-  "r12.2.5_to_r14.21.0_leap",
-  "r12.2.8_to_r14.21.0_leap",
+  "r12.1.2_to_r14.23.0_leap",
+  "r12.2.2_to_r14.23.0_leap",
+  "r12.2.5_to_r14.23.0_leap",
+  "r12.2.8_to_r14.23.0_leap",
   "newton_to_queens_inc",
   "pike_to_queens_inc",
   "queens_to_rocky_inc"

--- a/leapfrog.rst
+++ b/leapfrog.rst
@@ -12,9 +12,9 @@ rpc-upgrades repo supports:
 
 Leapfrog upgrades from:
 
-* kilo to r14.21.0 (newton)
-* liberty to r14.21.0 (newton)
-* mitaka to r14.21.0 (newton)
+* kilo to r14.23.0 (newton)
+* liberty to r14.23.0 (newton)
+* mitaka to r14.23.0 (newton)
 
 Job Testing
 -----------
@@ -41,7 +41,7 @@ Terms
 * `OSA-OPS <https://github.com/openstack/openstack-ansible-ops>`_:  OpenStack Operations
 * `Kilo <https://github.com/rcbops/rpc-openstack/tree/kilo>`_: The RPCO release of OpenStack Kilo
 * `Liberty <https://github.com/rcbops/rpc-openstack/tree/liberty>`_: The RPCO release of OpenStack Liberty
-* `r14.21.0 <https://github.com/rcbops/rpc-openstack/tree/r14.21.0>`_: The RPCO release of OpenStack Newton.
+* `r14.23.0 <https://github.com/rcbops/rpc-openstack/tree/r14.23.0>`_: The RPCO release of OpenStack Newton.
 
 Pre Upgrade Tasks
 ------------------
@@ -92,11 +92,11 @@ containers on CONTAINERS_TO_DESTROY as this will override the default that inclu
 
     export CONTAINERS_TO_DESTROY='all_containers:!galera_all:!neutron_agent:!ceph_all:!rsyslog_all:!elasticsearch_all:!swift_all'
 
-**Note:** *Currently the rpc-upgrades repo targets r14.21.0.  If you want to deploy the previous version you can:*
+**Note:** *Currently the rpc-upgrades repo targets r14.23.0.  If you want to deploy the previous version you can:*
 
 .. code-block:: shell
 
-   export RPC_TARGET_CHECKOUT=r14.20.0
+   export RPC_TARGET_CHECKOUT=r14.22.0
 
 If you cannot locate `/etc/openstack-release` or it is outdated. Export the release version which upgrade from manually:
 

--- a/releasenotes/notes/2019-january-releases-d1bcc4d107352cdb.yaml
+++ b/releasenotes/notes/2019-january-releases-d1bcc4d107352cdb.yaml
@@ -1,7 +1,7 @@
 ---
 features:
   - |
-    Leaps to Newton r14.21.0
+    Leaps to Newton r14.23.0
 issues:
   - |
     Additional bug fixes/optimizations to Incremental upgrades

--- a/scripts/ubuntu14-leapfrog.sh
+++ b/scripts/ubuntu14-leapfrog.sh
@@ -51,7 +51,7 @@ export POST_LEAP_STEPS="${LEAP_BASE_DIR}/post_leap.sh"
 export RPCD_DEFAULTS='/etc/openstack_deploy/user_rpco_variables_defaults.yml'
 export OA_DEFAULTS='/etc/openstack_deploy/user_osa_variables_defaults.yml'
 # Set the target checkout used when leaping forward.
-export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'r14.21.0'}
+export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'r14.23.0'}
 export RPC_APT_ARTIFACT_MODE=loose
 export QC_TEST=${QC_TEST:-'no'}
 export RUN_PREFLIGHT=${RUN_PREFLIGHT:-yes}

--- a/testing.rst
+++ b/testing.rst
@@ -33,7 +33,7 @@ you wish to test with.
 
 .. code-block:: shell
 
-    export RE_JOB_ACTION=r12.2.8_to_r14.21.0_leap
+    export RE_JOB_ACTION=r12.2.8_to_r14.23.0_leap
     ./run-tests.sh
 
 

--- a/tests/create-mnaio-snap.sh
+++ b/tests/create-mnaio-snap.sh
@@ -60,7 +60,7 @@ function determine_manifest {
      if [ "${RE_JOB_SERIES}" == "pike" ]; then
        export RPCO_IMAGE_MANIFEST_URL="${RPCO_ARTIFACT_URL}/r16.2.8-xenial_mnaio_no_artifacts-swift/manifest.json"
      elif [ "${RE_JOB_SERIES}" == "newton" ]; then
-       export RPCO_IMAGE_MANIFEST_URL="${RPCO_ARTIFACT_URL}/r14.21.0-xenial_mnaio_loose_artifacts-swift/manifest.json"
+       export RPCO_IMAGE_MANIFEST_URL="${RPCO_ARTIFACT_URL}/r14.23.0-xenial_mnaio_loose_artifacts-swift/manifest.json"
      else
        exit 1
      fi


### PR DESCRIPTION
Bumps rpc-upgrades to use r14.23.0 for leapfrogs.

https://github.com/rcbops/rpc-openstack/tree/r14.23.0