### PR TITLE
Configure lxc_container_backing_store

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -196,20 +196,24 @@ function generate_upgrade_config {
 }
 
 function prepare_ocata {
-  if [[ ! -f "/etc/openstack_deploy/ocata_upgrade_prep.complete" ]]; then
-    pushd /opt/rpc-upgrades/incremental/playbooks
+  pushd /opt/rpc-upgrades/incremental/playbooks
+    openstack-ansible configure-lxc-backend.yml
+
+    if [[ ! -f "/etc/openstack_deploy/ocata_upgrade_prep.complete" ]]; then
       openstack-ansible prepare-ocata-upgrade.yml
-    popd
-  fi
-  if [[ ! -f "/etc/openstack_deploy/ocata_migrate.complete" ]]; then
-    pushd /opt/rpc-upgrades/incremental/playbooks
+    fi
+
+    if [[ ! -f "/etc/openstack_deploy/ocata_migrate.complete" ]]; then
       openstack-ansible create-cell0.yml
       openstack-ansible db-migration-ocata.yml
-    popd
-  fi
+  popd
 }
 
 function prepare_pike {
+  pushd /opt/rpc-upgrades/incremental/playbooks
+    openstack-ansible configure-lxc-backend.yml
+  popd
+
   pushd /opt/openstack-ansible
     # patch in restarting of containers into run-upgrade
     cp /opt/rpc-upgrades/playbooks/patches/pike/lxc-containers-restart.yml /opt/openstack-ansible/scripts/upgrade-utilities/playbooks
@@ -219,7 +223,9 @@ function prepare_pike {
 }
 
 function prepare_queens {
-  echo "Queens prepare steps go here..."
+  pushd /opt/rpc-upgrades/incremental/playbooks
+    openstack-ansible configure-lxc-backend.yml
+  popd
 }
 
 function prepare_rocky {

--- a/incremental/playbooks/configure-lxc-backend.yml
+++ b/incremental/playbooks/configure-lxc-backend.yml
@@ -1,0 +1,35 @@
+---
+
+- hosts: localhost
+  gather_facts: "{{ gather_facts | default(false) }}"
+  tasks:
+    - name: Get current lxc.rootfs.backend from first container
+      command: "lxc-info -n {{ hostvars[item]['container_name'] }} -c lxc.rootfs.backend"
+      with_items: "{{ groups['all_containers'] |first }}"
+      changed_when: false
+      delegate_to: "{{ hostvars[item]['physical_host'] }}"
+      register: _repo_backend_rootfs
+      until: _repo_backend_rootfs |success
+      retries: 3
+      delay: 5
+      failed_when: not _repo_backend_rootfs.stdout is search('lxc.rootfs.backend')
+
+    - set_fact:
+        lxc_backend: "{{ _repo_backend_rootfs.results[0].stdout.split('=')[1] |trim() }}"
+
+    - name: Find overrides file
+      stat:
+        path: "/etc/openstack_deploy/{{ item }}"
+        follow: yes
+      changed_when: false
+      register: _osa_config
+      until: _osa_config |success
+      with_items:
+        - 'user_osa_variables_overrides.yml'
+        - 'user_variables.yml'
+
+    - name: Configure lxc_container_backing_store
+      lineinfile:
+        dest: "{{ _osa_config.results[0].stat.path }}"
+        line: "lxc_container_backing_store: {{ lxc_backend }}"
+        regexp: '^lxc_container_backing_store:.*'


### PR DESCRIPTION
The override lxc_container_backing_store default value changes throughout
the upgrade and can lead to situation that new containers use a different
backend compared to existing one.
A new playbook `configure-lxc-backend.yml` is provided to ensure that
the existing backend is retained throughout the lifecyle.

Closes-Bug: #FLEEK-267