### PR TITLE
Bootstrap OSA if it hasn't been done before

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -129,6 +129,23 @@ function checkout_openstack_ansible {
   fi
 }
 
+function ensure_osa_bootstrap {
+  if [ ! -f "/etc/openstack_deploy/osa_bootstrapped.complete" ]; then
+    # purge osa and wrapper so that we start fresh without RPC-O settings
+    if [ -d "/opt/openstack-ansible" ]; then
+      rm -rf /opt/openstack-ansible
+      rm -f /usr/local/bin/openstack-ansible
+      rm -f /usr/local/bin/openstack-ansible.rc
+    fi
+    checkout_openstack_ansible
+    pushd /opt/openstack-ansible
+      scripts/bootstrap-ansible.sh
+    popd
+    touch /etc/openstack_deploy/osa_bootstrapped.complete
+  fi
+}
+
+
 function configure_rpc_openstack {
   rsync -av --delete /opt/rpc-openstack/etc/openstack_deploy/group_vars /etc/openstack_deploy/
   rm -rf /opt/rpc-ansible
@@ -189,12 +206,6 @@ function prepare_ocata {
       openstack-ansible create-cell0.yml
       openstack-ansible db-migration-ocata.yml
     popd
-  fi
-  # purge osa and wrapper so that we start fresh without RPC-O settings
-  if [ -d "/opt/openstack-ansible" ]; then
-    rm -rf /opt/openstack-ansible
-    rm -f /usr/local/bin/openstack-ansible
-    rm -f /usr/local/bin/openstack-ansible.rc
   fi
 }
 

--- a/incremental/ubuntu16-upgrade-to-ocata.sh
+++ b/incremental/ubuntu16-upgrade-to-ocata.sh
@@ -32,6 +32,7 @@ prepare_ocata
 
 checkout_rpc_openstack
 checkout_openstack_ansible
+ensure_osa_bootstrap
 
 if [[ "$SKIP_INSTALL" == "yes" ]]; then
   exit 0

--- a/incremental/ubuntu16-upgrade-to-pike.sh
+++ b/incremental/ubuntu16-upgrade-to-pike.sh
@@ -30,6 +30,7 @@ echo "Starting Ocata to Pike Upgrade..."
 
 checkout_rpc_openstack
 configure_rpc_openstack
+ensure_osa_bootstrap
 prepare_pike
 
 if [[ "$SKIP_INSTALL" == "yes" ]]; then

--- a/incremental/ubuntu16-upgrade-to-queens.sh
+++ b/incremental/ubuntu16-upgrade-to-queens.sh
@@ -30,6 +30,7 @@ echo "Starting Pike to Queens Upgrade..."
 
 checkout_rpc_openstack
 configure_rpc_openstack
+ensure_osa_bootstrap
 prepare_queens
 run_upgrade
 

--- a/incremental/ubuntu16-upgrade-to-rocky.sh
+++ b/incremental/ubuntu16-upgrade-to-rocky.sh
@@ -30,6 +30,7 @@ echo "Starting Queens to Rocky Upgrade..."
 
 checkout_rpc_openstack
 configure_rpc_openstack
+ensure_osa_bootstrap
 prepare_rocky
 run_upgrade
 


### PR DESCRIPTION
Ensures OSA bootstrap is ran to overwrite any RPC-O
specific bootstraps.  Writes a file to ensure it's
done at least once to flip things over so that we
always have OSA openstack-ansible available.