### PR TITLE
FLEEK-268 Check for apt_pinned_packages in overrides

### DIFF
--- a/playbooks/preflight-check.yml
+++ b/playbooks/preflight-check.yml
@@ -211,6 +211,23 @@
         - nfs_mount_found.rc == 0
         - glance_nfs_client is undefined
 
+- name: Check for apt_pinned_packages in openstack_deploy
+  hosts: localhost
+  gather_facts: false
+  user: root
+  tasks:
+    - name: Check for apt_pinned_packages in overrides
+      command: "grep 'apt_pinned_packages' user_rpco_variables_overrides.yml user_osa_variables_overrides.yml"
+      args:
+        chdir: /etc/openstack_deploy
+      failed_when: false
+      register: setting_found
+
+    - name: fail if found
+      fail:
+        msg: "apt_pinned_packages appears set in /etc/openstack_deploy, please evaluate and remove before continuing."
+      when: setting_found.rc == 0
+
 - name: Mark preflight check as having run
   hosts: localhost
   gather_facts: false


### PR DESCRIPTION
apt_pinned_packages can break things during upgrades as
it overrides all pins in all roles.

This will fail if that variable is present prompting the user
to investigate and remove the setting if present.