### PR TITLE
Populate user_variables.yml as it's empty

### DIFF
--- a/tests/prepare-rpco.sh
+++ b/tests/prepare-rpco.sh
@@ -274,6 +274,7 @@ function remove_ceph_roles {
 function fixup_mitaka {
   sed -i '/# Enable playbook callbacks from OSA/,+1d' ${RPCO_PATH}/scripts/deploy.sh
   sed -i '/# Apply any patched files./,+2d' ${RPCO_PATH}/scripts/deploy.sh
+  echo "thisisadummyvariable: True" >> /etc/openstack_deploy/user_variables.yml
 }
 
 function fix_kilo_arr {


### PR DESCRIPTION
When using an MNAIO, user_variables.yml for Mitaka is present but nothing is in it causing deploy.sh to fail.  This tosses a dummy var into it to prevent the failure.