### PR TITLE
Disable RPC playbooks on MNAIO

### DIFF
--- a/tests/create-mnaio.sh
+++ b/tests/create-mnaio.sh
@@ -195,7 +195,7 @@ case "${RE_JOB_SERIES}" in
                   export DEPLOY_CEILOMETER=no; \
                   export DEPLOY_CEPH=no; \
                   export DEPLOY_SWIFT=yes; \
-                  export DEPLOY_RPC=yes; \
+                  export DEPLOY_RPC=no; \
                   export ANSIBLE_FORCE_COLOR=true; \
                   export RPC_APT_ARTIFACT_MODE="loose"; \
                   scripts/deploy.sh"


### PR DESCRIPTION
A lot of older RPC playbooks are busted and we've moved a lot
of those components into external repos.  This removes
them during gate testing to reduce times and make tests more
stable.