### PR TITLE
User extras secrets fix

### DIFF
--- a/scripts/post_leap.sh
+++ b/scripts/post_leap.sh
@@ -22,6 +22,7 @@ set -o pipefail
 # set encrypted vault files
 export OS_DEPLOY_DIR="/etc/openstack_deploy"
 export VAULT_ENCRYPTED_FILES="user_secrets.yml
+                              user_extras_secrets.yml
                               user_osa_secrets.yml
                               user_rpco_secrets.yml"
 

--- a/scripts/pre_leap.sh
+++ b/scripts/pre_leap.sh
@@ -22,6 +22,7 @@ set -o pipefail
 # set encrypted vault files
 export OS_DEPLOY_DIR="/etc/openstack_deploy"
 export VAULT_ENCRYPTED_FILES="user_secrets.yml
+                              user_extras_secrets.yml
                               user_osa_secrets.yml
                               user_rpco_secrets.yml"
 

--- a/tests/test-leapfrog.sh
+++ b/tests/test-leapfrog.sh
@@ -21,6 +21,7 @@ export AUTOMATIC_VAR_MIGRATE_FLAG="--for-testing-take-new-vars-only"
 export RPC_TARGET_CHECKOUT=${RPC_TARGET_CHECKOUT:-'newton'}
 export OS_DEPLOY_DIR="/etc/openstack_deploy"
 export VAULT_ENCRYPTED_FILES="user_secrets.yml
+                              user_extras_secrets.yml
                               user_osa_secrets.yml
                               user_rpco_secrets.yml"
 


### PR DESCRIPTION
The file `user_extras_secrets.yml` was forgotten to be decrypted during the upgrade, leading to corruption/destruction of the file/content