### PR TITLE
Queens repo containers cleanup

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -176,6 +176,14 @@ function run_upgrade {
     export I_REALLY_KNOW_WHAT_I_AM_DOING=true
     export SETUP_ARA=true
     export ANSIBLE_CALLBACK_PLUGINS=/etc/ansible/roles/plugins/callback:/opt/ansible-runtime/local/lib/python2.7/site-packages/ara/plugins/callbacks
+
+    # Destroy repo container prior to the upgrade to reduce "No space left on device" issues
+    pushd /opt/openstack-ansible/playbooks
+      openstack-ansible lxc-containers-destroy.yml -e force_containers_destroy=true -e force_containers_data_destroy=true --limit repo_container
+      openstack-ansible lxc-containers-create.yml --limit repo_container -e lxc_container_fs_size=10G
+    popd
+
+    # Run upgrade
     echo "YES" | bash scripts/run-upgrade.sh
   popd
 }


### PR DESCRIPTION
As preparation for the queens upgrade, the
repo containers are be destroyed in order to free up
disk space occupied by previous upgrades.
This reduces potential issues, where the root device runs
out of disk space