### PR TITLE
Testing boosting infra nodes to 10 vcpus

### DIFF
--- a/tests/create-mnaio-snap.sh
+++ b/tests/create-mnaio-snap.sh
@@ -108,6 +108,7 @@ pushd /opt/openstack-ansible-ops/multi-node-aio
   else
     source /opt/rpc-upgrades/gating/mnaio_vars.sh
   fi
+  export MNAIO_ANSIBLE_PARAMETERS="-e default_vm_disk_mode=file -e infra_vm_server_vcpus=10"
   source bootstrap.sh
   source ansible-env.rc
   determine_manifest


### PR DESCRIPTION
Testing timing in gating to see if job time increases
when moving from 4 vcpus to 10 on infras.