### PR TITLE
Pin tests to working branch

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,8 +29,9 @@ setenv =
     PYTHONPATH={envsitepackagesdir}
     ### OSA specific call back files
     # Set the checkout to any supported tag, branch, or sha.
-    OSA_TESTS_CHECKOUT=master
-    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_TESTS_CHECKOUT:master}
+    OSA_TESTS_CHECKOUT=d90acf00b639496cd0669153534fe5588875f3ee
+    OSA_CONSTRAINTS_CHECKOUT=377fde64ac16dc94da2e29e16a4102adcc081a6e
+    UPPER_CONSTRAINTS_FILE=https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h={env:OSA_CONSTRAINTS_CHECKOUT:master}
     OSA_TEST_DEPS=https://git.openstack.org/cgit/openstack/openstack-ansible-tests/plain/test-ansible-deps.txt?h={env:OSA_TESTS_CHECKOUT:master}
 
 


### PR DESCRIPTION
Pin tests to working branch.  Newer commit to openstack-ansible-tests broke things, so we're pinning to last known working for now.

https://github.com/openstack/openstack-ansible-tests/commit/bb9d690eb09360fe03bf16bcfa0ffa2e2e8f5826