### PR TITLE
Adding prepare-queens-upgrade.yml playbook

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -245,6 +245,10 @@ function prepare_pike {
 function prepare_queens {
   pushd /opt/rpc-upgrades/incremental/playbooks
     openstack-ansible configure-lxc-backend.yml
+
+    if [[ ! -f "/etc/openstack_deploy/queens_upgrade_prep.complete" ]]; then
+      openstack-ansible prepare-queens-upgrade.yml
+    fi
   popd
 }
 

--- a/incremental/playbooks/prepare-queens-upgrade.yml
+++ b/incremental/playbooks/prepare-queens-upgrade.yml
@@ -1,0 +1,40 @@
+---
+# Copyright 2019, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This task is necessary in order to allow proper apt cache rebuilds
+# during setup-hosts.yml right after the repo container have been rebuilt.
+# The apt-cacher-ng services is reinstalled during the infrastructure phase.
+- name: Remove apt-cacher-ng settings
+  hosts: hosts:all_containers
+  gather_facts: "{{ gather_facts | default(false) }}"
+  user: root
+  tasks:
+    - name: Remove existing apt configuration files
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - /etc/apt/apt.conf.d/00apt-cacher-proxy
+      ignore_errors: true
+
+- name: Fix up config files
+  hosts: localhost
+  user: root
+  tasks:
+    - name: Set lock file
+      file:
+        path: /etc/openstack_deploy/rpc-upgrades/queens_upgrade_prep.complete
+        state: touch
+        mode: 0644


### PR DESCRIPTION
The playbook is used to execute task prior to the
queens upgrade