### PR TITLE
Remove rpc-repo GPG keys

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -197,6 +197,11 @@ function run_upgrade {
       openstack-ansible lxc-containers-create.yml --limit repo-infra_all -e lxc_container_fs_size=10G
     popd
 
+    # ensure no traces of rpco repos that may have come from lxc-cache
+    pushd /opt/rpc-upgrades/incremental/playbooks
+      openstack-ansible remove-rpco-repos.yml
+    popd
+
     # Remove pip from deploy host to prevent issues before repo has been rebuilt
     if [ -f /root/.pip/pip.conf ]; then
       rm /root/.pip/pip.conf

--- a/incremental/playbooks/prepare-ocata-upgrade.yml
+++ b/incremental/playbooks/prepare-ocata-upgrade.yml
@@ -38,6 +38,11 @@
         - /etc/apt/sources.list.d/rpco.list
         - /etc/apt/sources.list.d/rax-maas.list
       ignore_errors: true
+
+    - name: Remove rpc-repo GPG keys
+      apt_key:
+        id: 52AA252F
+        state: absent
    
     - name: Refresh apt cache
       apt:

--- a/incremental/playbooks/remove-rpco-repos.yml
+++ b/incremental/playbooks/remove-rpco-repos.yml
@@ -1,0 +1,37 @@
+---
+# Copyright 2019, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Ensure all rpco repos are removed from repo containers
+  hosts: repo-infra_all
+  user: root
+  tasks:
+    - name: Remove existing artifact repos
+      file:
+        path: "{{ item }}"
+        state: absent
+      with_items:
+        - /etc/apt/sources.list.d/rpco.list
+        - /etc/apt/sources.list.d/rax-maas.list
+      ignore_errors: true
+
+    - name: Remove rpc-repo GPG keys
+      apt_key:
+        id: 52AA252F
+        state: absent
+
+    - name: Refresh apt cache
+      apt:
+        update_cache: yes
+      ignore_errors: true


### PR DESCRIPTION
Removes rpc-repo keys as they aren't used past Newton and prevents
apt update failures from expired keys.