### PR TITLE
Drop out rpc-o specifics and use OSA for upgrades

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -117,21 +117,6 @@ function check_user_variables {
   fi
 }
 
-function checkout_rpc_openstack {
-  if [ ! -d "/opt/rpc-openstack" ]; then
-    git clone --branch ${RPC_BRANCH} --recursive https://github.com/rcbops/rpc-openstack /opt/rpc-openstack
-  else
-    pushd /opt/rpc-openstack
-      git clean -df
-      git reset --hard HEAD
-      git fetch --all
-      rm -rf openstack-ansible
-      rm -rf scripts/artifacts-building/
-      git checkout ${RPC_BRANCH}
-    popd
-  fi
-}
-
 function checkout_openstack_ansible {
   if [ ! -d "/opt/openstack-ansible" ]; then
     git clone --recursive https://github.com/openstack/openstack-ansible /opt/openstack-ansible
@@ -170,14 +155,8 @@ function ensure_osa_bootstrap {
 }
 
 
-function configure_rpc_openstack {
-  rsync -av --delete /opt/rpc-openstack/etc/openstack_deploy/group_vars /etc/openstack_deploy/
-  rm -rf /opt/rpc-ansible
-  virtualenv /opt/rpc-ansible
-  install_ansible_source
-  pushd /opt/rpc-openstack/playbooks
-    /opt/rpc-ansible/bin/ansible-playbook -i 'localhost,' site-release.yml
-  popd
+function configure_osa {
+  rm -rf /etc/openstack_deploy/group_vars
   # clean out any existing env.d inventory
   if [ -d "/etc/openstack_deploy/env.d" ]; then
     rm -rf /etc/openstack_deploy/env.d

--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -156,11 +156,10 @@ function ensure_osa_bootstrap {
 
 
 function configure_osa {
-  rm -rf /etc/openstack_deploy/group_vars
-  # clean out any existing env.d inventory
-  if [ -d "/etc/openstack_deploy/env.d" ]; then
-    rm -rf /etc/openstack_deploy/env.d
-  fi
+  # check for existing env.d files and remove rpc-o specific group_vars
+  pushd /opt/rpc-upgrades/incremental/playbooks
+    openstack-ansible config-file-check.yml
+  popd
 }
 
 function install_ansible_source {

--- a/incremental/playbooks/config-file-check.yml
+++ b/incremental/playbooks/config-file-check.yml
@@ -1,0 +1,69 @@
+---
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Prepare environment and configuration for deploying the new release
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  user: root
+  vars:
+    repo_root_dir: "{{ (playbook_dir ~ '/../../') | realpath }}"
+    ansible_python_interpreter: "/usr/bin/python"
+  tasks:
+    - name: Ensure rpc-openstack specific group_var overrides are removed
+      file:
+        path: "/etc/openstack_deploy/group_vars/{{ item }}"
+        state: absent
+      with_items:
+        - mariadb.yml
+        - osa.yml
+        - release.yml
+        - rpc-o.yml
+
+    - name: Remove unnecessary env.d override files
+      shell: |
+        set -e
+        exit_code=0
+        if [[ -e /etc/openstack_deploy/env.d ]]; then
+          for f in $(diff --brief --report-identical-files /etc/openstack_deploy/env.d /opt/openstack-ansible/inventory/env.d | awk '/identical/ {print $2}' 2>/dev/null); do
+            echo "Deleting ${f} because it is identical to the defaults."
+            rm -f ${f}
+            exit_code=2
+          done
+        fi
+        exit ${exit_code}
+      args:
+        executable: /bin/bash
+      register: _envd_dir_cleanup
+      changed_when: _envd_dir_cleanup.rc == 2
+      failed_when: _envd_dir_cleanup.rc not in [0,2]
+
+    - name: Find any config files in the user-space env.d directory
+      find:
+        paths:
+          - "/etc/openstack_deploy/env.d"
+        patterns: '*.yml'
+      register: _envd_dir_contents
+
+    - name: Halt the upgrade and warn the user to inspect the env.d files for changes
+      fail:
+        msg: |
+          There are files in /etc/openstack_deploy/env.d which override the default inventory
+          layout in {{ repo_root_dir }}/inventory/env.d. The difference between these files
+          should be carefully reviewed to understand whether the changes are still necessary
+          and applicable to the environment. If all the user-space env.d files are necessary,
+          then please export SKIP_CUSTOM_ENVD_CHECK=true and re-run the playbook or
+          run-upgrade.sh script.
+      when:
+        - _envd_dir_contents.matched > 0
+        - not(lookup('env', 'SKIP_CUSTOM_ENVD_CHECK') | bool)

--- a/incremental/ubuntu16-upgrade-to-ocata.sh
+++ b/incremental/ubuntu16-upgrade-to-ocata.sh
@@ -21,7 +21,6 @@ source lib/vars.sh
 
 require_ubuntu_version 16
 
-export RPC_BRANCH=${RPC_BRANCH:-'ocata'}
 export RPC_PRODUCT_RELEASE="ocata"
 export OSA_SHA="stable/ocata"
 export SKIP_INSTALL=${SKIP_INSTALL:-"yes"}
@@ -32,7 +31,6 @@ mark_started
 # to prepare for an OSA deploy
 prepare_ocata
 
-checkout_rpc_openstack
 checkout_openstack_ansible
 ensure_osa_bootstrap
 

--- a/incremental/ubuntu16-upgrade-to-pike.sh
+++ b/incremental/ubuntu16-upgrade-to-pike.sh
@@ -21,15 +21,14 @@ source lib/vars.sh
 
 require_ubuntu_version 16
 
-export RPC_BRANCH=${RPC_BRANCH:-'r16.2.9'}
 export OSA_SHA="stable/pike"
 export RPC_PRODUCT_RELEASE="pike"
 export RPC_ANSIBLE_VERSION="2.3.2.0"
 
 mark_started
-checkout_rpc_openstack
-configure_rpc_openstack
+checkout_openstack_ansible
 ensure_osa_bootstrap
+configure_osa
 prepare_pike
 run_upgrade
 mark_completed

--- a/incremental/ubuntu16-upgrade-to-queens.sh
+++ b/incremental/ubuntu16-upgrade-to-queens.sh
@@ -21,16 +21,15 @@ source lib/vars.sh
 
 require_ubuntu_version 16
 
-export RPC_BRANCH=${RPC_BRANCH:-'r17.1.4'}
 export OSA_SHA="stable/queens"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
 export RPC_PRODUCT_RELEASE="queens"
 export RPC_ANSIBLE_VERSION="2.4.3.0"
 
 mark_started
-checkout_rpc_openstack
-configure_rpc_openstack
+checkout_openstack_ansible
 ensure_osa_bootstrap
+configure_osa
 prepare_queens
 run_upgrade
 mark_completed

--- a/incremental/ubuntu16-upgrade-to-rocky.sh
+++ b/incremental/ubuntu16-upgrade-to-rocky.sh
@@ -21,16 +21,15 @@ source lib/vars.sh
 
 require_ubuntu_version 16
 
-export RPC_BRANCH=${RPC_BRANCH:-'rocky'}
 export OSA_SHA="stable/rocky"
 export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
 export RPC_PRODUCT_RELEASE="rocky"
 export RPC_ANSIBLE_VERSION="2.5.5"
 
 mark_started
-checkout_rpc_openstack
-configure_rpc_openstack
+checkout_openstack_ansible
 ensure_osa_bootstrap
+configure_osa
 prepare_rocky
 run_upgrade
 mark_completed


### PR DESCRIPTION
Removes RPC-O specific parts and relies on upstream for checking out each stable version of OSA to walk through the incremental upgrades.  Utilizes group_vars and env.d files from each upstream OSA release.  Ensures we're using the latest OSA stable branches for upgrades instead of relying on the outdated RPC-O builds.

Adds inspector for env.d files and alerts user if there are custom settings.  It purges any that match the release and leaves the ones that don't remaining for the operator to adjust.  The operator can then choose to skip the check if they are comfortable with those changes.