### PR TITLE
Disable AIO RPC playbook install

### DIFF
--- a/tests/create-aio.sh
+++ b/tests/create-aio.sh
@@ -55,6 +55,7 @@ pushd /opt/rpc-openstack
   export DEPLOY_MAAS="false"
   export DEPLOY_AIO="yes"
   export DEPLOY_HARDENING="no"
+  export DEPLOY_RPC="no"
   export RPC_APT_ARTIFACT_MODE="loose"
   scripts/deploy.sh
 popd


### PR DESCRIPTION
Due to various bitrot from things like horizon playbooks,
drop these from the install to simplify testing.  Most recent one is markdown breaking since it's not pinned in the horizon extensions repo:

```
2019-04-10T13:24:49-0500 TASK: [horizon_extensions | Install Horizon plugin] *************************** 
2019-04-10T13:25:02-0500 failed: [aio1_horizon_container-b8c6a4df] => {"changed": true, "cmd": ["python", "setup.py", "install"], "delta": "0:00:12.286921", "end": "2019-04-10 18:25:02.156632", "rc": 1, "start": "2019-04-10 18:24:49.869711", "warnings": []}
2019-04-10T13:25:02-0500 stderr: warning: no files found matching 'LICENSE'
2019-04-10T13:25:02-0500 zip_safe flag not set; analyzing archive contents...
2019-04-10T13:25:02-0500 rackspace.heat_store.views: module references __file__
2019-04-10T13:25:02-0500 /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'python_requires'
2019-04-10T13:25:02-0500   warnings.warn(msg)
2019-04-10T13:25:02-0500 warning: no files found matching 'MANIFEST'
2019-04-10T13:25:02-0500 zip_safe flag not set; analyzing archive contents...
2019-04-10T13:25:02-0500 /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'long_description_content_type'
2019-04-10T13:25:02-0500   warnings.warn(msg)
2019-04-10T13:25:02-0500 /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'project_urls'
2019-04-10T13:25:02-0500   warnings.warn(msg)
2019-04-10T13:25:02-0500 /usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'python_requires'
2019-04-10T13:25:02-0500   warnings.warn(msg)
2019-04-10T13:25:02-0500 warning: no previously-included files found matching 'pyproject.toml'
2019-04-10T13:25:02-0500 error: The 'setuptools>=36' distribution was not found and is required by Markdown
```