### PR TITLE
Ensure psmisc is present

### DIFF
--- a/incremental/playbooks/prepare-ocata-upgrade.yml
+++ b/incremental/playbooks/prepare-ocata-upgrade.yml
@@ -49,6 +49,15 @@
         update_cache: yes
       ignore_errors: true
 
+- name: Install psmisc package for killall command
+  hosts: hosts
+  user: root
+  tasks:
+    - name: Install psmisc to ensure killall is present for lxc-dnsmasq
+      apt:
+        name: psmisc
+        state: present
+
 - name: Fix up config files before Ocata jump
   hosts: localhost
   user: root


### PR DESCRIPTION
Patch has been submitted upstream to correct issue where killall wasn't
present and caused lxc-dnsmasq to not clean out existing
instances of dnsmasq.

Adding here temporarily to ensure it gets installed.  This should
negate the need for running the lxc-containers-restart.yml
that is used during the upgrade.