### PR TITLE
Remove maas and rpc-playbooks from post-leap

### DIFF
--- a/tests/create-mnaio-snap.sh
+++ b/tests/create-mnaio-snap.sh
@@ -137,7 +137,7 @@ if [ ! -f /etc/openstack_deploy/user_variables.yml ]; then
 osa_ops_mnaio: true
 EOF
 fi
- 
+
 set -xe
 echo "+---------------- MNAIO RELEASE AND KERNEL --------------+"
 lsb_release -a


### PR DESCRIPTION
Previously leap tried to do additional items that have
now been broken out into other steps.  This removes
those steps from the leapfrog process.