### PR TITLE
Adding early newton overrides

### DIFF
--- a/scripts/pre_redeploy.sh
+++ b/scripts/pre_redeploy.sh
@@ -163,4 +163,7 @@ glance_registry_rolling: '100%'
 EOF
 
 # rsync group_vars from RPC-O repo
-rsync -av --delete ${RPCO_DEFAULT_FOLDER}/group_vars /etc/openstack_deploy/
+if [ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/rpco-group-vars-sync.complete" ]; then
+  rsync -av --delete ${RPCO_DEFAULT_FOLDER}/group_vars /etc/openstack_deploy/
+  touch "${UPGRADE_LEAP_MARKER_FOLDER}/rpco-group-vars-sync.complete"
+fi


### PR DESCRIPTION
The overrides nova_api_galera_address, nova_system_user_name
are required when upgrading from early newton.
Additionally prepare-ocata-upgrade.yml is optimized to remove
a redundant task as `user_osa_variables_defaults.yml` is removed
already as file