### PR TITLE
Inspect files in env.d for deviations

### DIFF
--- a/incremental/lib/functions.sh
+++ b/incremental/lib/functions.sh
@@ -178,10 +178,10 @@ function configure_rpc_openstack {
   pushd /opt/rpc-openstack/playbooks
     /opt/rpc-ansible/bin/ansible-playbook -i 'localhost,' site-release.yml
   popd
-  # clean out any existing env.d inventory
-  if [ -d "/etc/openstack_deploy/env.d" ]; then
-    rm -rf /etc/openstack_deploy/env.d
-  fi
+  # check for existing env.d files
+  pushd /opt/rpc-upgrades/incremental/playbooks
+    openstack-ansible envd-file-check.yml
+  popd
 }
 
 function install_ansible_source {

--- a/incremental/playbooks/envd-file-check.yml
+++ b/incremental/playbooks/envd-file-check.yml
@@ -1,0 +1,65 @@
+---
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Prepare environment and configuration for deploying the new release
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  user: root
+  vars:
+    repo_root_dir: "{{ (playbook_dir ~ '/../../') | realpath }}"
+    ansible_python_interpreter: "/usr/bin/python"
+  tasks:
+    - name: Remove unnecessary env.d override files
+      shell: |
+        set -e
+        exit_code=0
+        if [[ -e /etc/openstack_deploy/env.d ]]; then
+          for f in $(diff --brief --report-identical-files /etc/openstack_deploy/env.d /opt/openstack-ansible/inventory/env.d | awk '/identical/ {print $2}' 2>/dev/null); do
+            echo "Deleting ${f} because it is identical to the defaults."
+            rm -f ${f}
+            exit_code=2
+          done
+        fi
+        exit ${exit_code}
+      args:
+        executable: /bin/bash
+      register: _envd_dir_cleanup
+      changed_when: _envd_dir_cleanup.rc == 2
+      failed_when: _envd_dir_cleanup.rc not in [0,2]
+      tags:
+        - identical-envd-file-cleanup
+
+    - name: Find any config files in the user-space env.d directory
+      find:
+        paths:
+          - "/etc/openstack_deploy/env.d"
+        patterns: '*.yml'
+      register: _envd_dir_contents
+      tags:
+        - custom-envd-file-check
+
+    - name: Halt the upgrade and warn the user to inspect the env.d files for changes
+      fail:
+        msg: |
+          There are files in /etc/openstack_deploy/env.d which override the default inventory
+          layout in {{ repo_root_dir }}/inventory/env.d. The difference between these files
+          should be carefully reviewed to understand whether the changes are still necessary
+          and applicable to the environment. If all the user-space env.d files are necessary,
+          then please export SKIP_CUSTOM_ENVD_CHECK=true and re-run the playbook or
+          run-upgrade.sh script.
+      when:
+        - _envd_dir_contents.matched > 0
+        - not(lookup('env', 'SKIP_CUSTOM_ENVD_CHECK') | bool)
+      tags:
+        - custom-envd-file-check


### PR DESCRIPTION
Pulls in check code from OSA stein to inspect env.d
files.  If there are modifications, user is prompted to check
and if they choose to ignore they have to:

export SKIP_CUSTOM_ENVD_CHECK=true