### PR TITLE
Adds additional reports for checking status

### DIFF
--- a/playbooks/roles/osa_health/defaults/main.yml
+++ b/playbooks/roles/osa_health/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+date_stamp: "{{ ansible_date_time.date }}"
+time_stamp: "{{ ansible_date_time.time |replace(':','')}}"
+datetime_stamp: "{{ date_stamp }}-{{ time_stamp }}"
+local_home: "{{ lookup('env', 'HOME') }}"

--- a/playbooks/roles/osa_health/tasks/main.yml
+++ b/playbooks/roles/osa_health/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+
+# set backup_dir as a fact to ensure dir name doesn't change during run
+- name: Set backup dir to use
+  local_action:
+    module: set_fact
+    backup_dir: "{{ ansible_env.BKUPDIR |default(local_home+'/'+'rpc-upgrade-'+date_stamp) }}"
+  run_once: true
+
+- name: Update apt cache to generate latest packages list
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: Check for security updates
+  shell: 'apt-get -s --no-download dist-upgrade -V | grep "^Inst.*security.*$" | cut -d " " -f 2'
+  register: security_updates
+  failed_when: ( security_updates.rc not in [ 0, 1 ] )
+
+- name: Check for regular updates
+  shell: 'apt-get -s --no-download dist-upgrade -V | grep "^Inst.*updates.*$" | cut -d " " -f 2'
+  register: regular_updates
+  failed_when: ( regular_updates.rc not in [ 0, 1 ] )
+
+- set_fact:
+    security_updates_needed: "yes"
+  when: security_updates.rc == 0
+
+- name: Check for Zombies
+  shell: "ps axo stat,ppid,pid,comm | grep -w defunct"
+  register: zombie_check
+  failed_when: ( zombie_check.rc not in [ 0, 1 ] )
+
+- set_fact:
+    zombies_detected: "yes"
+  when: zombie_check.rc == 1
+
+- name: Generate reports
+  local_action:
+    module: template
+    src: "{{ item }}.txt.j2"
+    dest: "{{ backup_dir }}/{{ item }}-{{ datetime_stamp }}.txt"
+  run_once: true
+  with_items:
+    - hosts
+    - tldr
+    - zombies

--- a/playbooks/roles/osa_health/templates/hosts.txt.j2
+++ b/playbooks/roles/osa_health/templates/hosts.txt.j2
@@ -1,0 +1,21 @@
+-----------
+Host Report
+-----------
+Generated at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for host in groups['all'] %}
+---------------------------------------------------------------------------
+Hostname: {{ hostvars[host].inventory_hostname }}
+---------------------------------------------------------------------------
+OS: {{ hostvars[host].ansible_lsb.description }}
+Kernel: {{ hostvars[host].ansible_kernel }}
+Vendor: {{ hostvars[host].ansible_system_vendor }}
+Model: {{ hostvars[host].ansible_product_name }}
+BIOS Date: {{ hostvars[host].ansible_bios_date }}
+BIOS Version: {{ hostvars[host].ansible_bios_version }}
+Standard Package Updates Needed ({{ hostvars[host].regular_updates.stdout_lines | length }}): {{ hostvars[host].regular_updates.stdout_lines }}
+Security Updates Needed ({{ hostvars[host].security_updates.stdout_lines | length }}): {{ hostvars[host].security_updates.stdout_lines }}
+
+{% endfor %}
+---------------------------------------------------------------------------
+

--- a/playbooks/roles/osa_health/templates/tldr.txt.j2
+++ b/playbooks/roles/osa_health/templates/tldr.txt.j2
@@ -1,0 +1,27 @@
+----------------------------------------------
+Openstack Ansible Environment Pre-Upgrade TLDR
+----------------------------------------------
+Generated at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+-----------
+Host Checks
+-----------
+
+Security Updates Needed: {{ "\033[1m" }}{{ security_updates_needed | default('no') }}{{ "\033[0m" }}
+ - See {{ backup_dir }}/hosts-{{ datetime_stamp }}.txt for more details
+
+Zombies Detected: {{ "\033[1m" }}{{ zombies_detected | default('no') }}{{ "\033[0m" }}
+ - See {{ backup_dir }}/zombies-{{ datetime_stamp }}.txt for more details
+
+----------------
+Endpoints Checks
+----------------
+
+Public Endpoints {{ "\033[1m" }}{{ endpointlist_public_match | default('is a match to') }}{{ "\033[0m" }} external_lb_vip_address of {{ external_lb_vip_address }}.
+Internal Endpoints {{ "\033[1m" }}{{ endpointlist_internal_match | default('is a match to') }}{{ "\033[0m" }} internal_lb_vip_address of {{ internal_lb_vip_address }}.
+
+----------------
+OpenStack Checks
+----------------
+
+Service checks status

--- a/playbooks/roles/osa_health/templates/zombies.txt.j2
+++ b/playbooks/roles/osa_health/templates/zombies.txt.j2
@@ -1,0 +1,12 @@
+----------------
+Zombie Processes
+----------------
+Generated at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
+
+{% for host in groups['all'] %}
+{% if hostvars[host].zombie_check.rc == 0 %}
+Hostname: {{ hostvars[host].inventory_hostname }}
+{{ hostvars[host].zombie_check.stdout_lines }}
+{% endif %}
+{% endfor %}
+

--- a/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
+++ b/playbooks/roles/rpc_pre_upgrade/tasks/gather_stats.yml
@@ -94,6 +94,34 @@
   register: endpointlist_result
   delegate_to: "{{ groups['utility_all'][0] }}"
 
+- name: Gather openstack public endpoint list
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    openstack {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} endpoint list | grep -i public | grep -v {{ external_lb_vip_address }}
+  args:
+    executable: /bin/bash
+  register: endpointlist_public_result
+  delegate_to: "{{ groups['utility_all'][0] }}"
+  failed_when: ( endpointlist_public_result.rc not in [ 0, 1 ] )
+
+- name: Gather openstack internal endpoint list
+  shell: |
+    . {{ ansible_env.HOME }}/openrc
+    openstack {{ openrc_insecure |default(false) |bool |ternary('--insecure','') }} endpoint list | grep -i internal | grep -v {{ internal_lb_vip_address }}
+  args:
+    executable: /bin/bash
+  register: endpointlist_internal_result
+  delegate_to: "{{ groups['utility_all'][0] }}"
+  failed_when: ( endpointlist_internal_result.rc not in [ 0, 1 ] )
+
+- set_fact:
+    endpointlist_internal_match: "does not match"
+  when: endpointlist_internal_result.stdout_lines | length >= 1
+
+- set_fact:
+    endpointlist_public_match: "does not match"
+  when: endpointlist_public_result.stdout_lines | length >= 1
+
 - name: Gather running instances from mysql
   shell: "mysql -BN -e \"select uuid from instances where deleted=0 and vm_state='active' order by uuid\" nova"
   args:
@@ -113,7 +141,7 @@
     src: "{{ item }}.txt.j2"
     dest: "{{ backup_dir }}/{{ item }}-{{ datetime_stamp }}.txt"
   with_items:
-    - status
+    - openstack-status
     - instance-volume-mappings
     - running-instances
 

--- a/playbooks/roles/rpc_pre_upgrade/templates/openstack-status.txt.j2
+++ b/playbooks/roles/rpc_pre_upgrade/templates/openstack-status.txt.j2
@@ -39,7 +39,8 @@ neutron agent-list output as at {{ ansible_date_time.date }}-{{ ansible_date_tim
 
 
 openstack endpoint list output as at {{ ansible_date_time.date }}-{{ ansible_date_time.time }}
-Compare output to external_lb_vip_address: {{ external_lb_vip_address }}
+Public Endpoint {{ endpointlist_public_match | default('is a match to') }} external_lb_vip_address of {{ external_lb_vip_address }}
+Internal Endpoint {{ endpointlist_internal_match | default('is a match to') }} internal_lb_vip_address of {{ internal_lb_vip_address }}
 
 {% for line in endpointlist_result.stdout_lines %}
 {{ line }}

--- a/playbooks/rpc-pre-upgrades.yml
+++ b/playbooks/rpc-pre-upgrades.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2016, Rackspace US, Inc.
+# Copyright 2019, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,3 +19,10 @@
     - role: "rpc_pre_upgrade"
   tags:
     - rpc-pre-upgrades
+
+- name: Gather health/status info from all hosts and containers
+  hosts: all_containers:hosts
+  roles:
+    - role: "osa_health"
+  tags:
+    - osa-health


### PR DESCRIPTION
Checks list of endpoints to ensure lb addreses match  appropriate endpoints and lists in file.

Adds osa_health role for gathering data from all hosts and generates a TLDR report that can be easily parsed. The role currently generates a list of updates that need to be done on all containers/hosts and does a check for zombie processes.

Renames status file to openstack-status.