### PR TITLE
Adds initial support for upgrades to stein/train

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,10 +13,18 @@ run-upgrade.sh script provided in each release of Openstack Ansible.  They are u
 releases for releases Newton and on.  They allow a stairstep approach to upgrading the
 environment.
 
-Supported incremental upgrades (must be running on Ubuntu 16.04):
+Supported incremental upgrades:
+
+Ubuntu 16.04 required:
 
 * Newton to Pike (Ocata is skipped)
 * Newton to Queens
+* Queens to Rocky
+
+Ubuntu 18.04 required:
+
+* Rocky to Stein (testing)
+* Stein to Train (testing)
 
 Full docs for Incremental upgrades are `here <incremental.rst>`_.
 

--- a/incremental/incremental-upgrade.sh
+++ b/incremental/incremental-upgrade.sh
@@ -75,7 +75,7 @@ for RELEASE_TO_DO in ${TODO}; do
   if [ ! -f ${UPGRADES_WORKING_DIR}/upgrade-to-${RELEASE_TO_DO}.complete ]; then
     echo "Starting upgrade to ${RELEASE_TO_DO^}..."
     sleep 5
-    bash ubuntu16-upgrade-to-${RELEASE_TO_DO}.sh
+    bash ubuntu${DETECTED_VERSION}-upgrade-to-${RELEASE_TO_DO}.sh
   else
     echo
     echo "*** Previous upgrade to ${RELEASE_TO_DO^} was completed, moving onto next in series in 10 seconds...***"

--- a/incremental/lib/vars.sh
+++ b/incremental/lib/vars.sh
@@ -19,7 +19,9 @@ RELEASES="newton
           ocata
           pike
           queens
-          rocky"
+          rocky
+          stein
+          train"
 
 STARTING_RELEASE=false
 SKIP_PREFLIGHT=${SKIP_PREFLIGHT:-false}

--- a/incremental/ubuntu16-upgrade-to-pike.sh
+++ b/incremental/ubuntu16-upgrade-to-pike.sh
@@ -31,5 +31,6 @@ checkout_rpc_openstack
 configure_rpc_openstack
 ensure_osa_bootstrap
 prepare_pike
+repo_rebuild
 run_upgrade
 mark_completed

--- a/incremental/ubuntu16-upgrade-to-queens.sh
+++ b/incremental/ubuntu16-upgrade-to-queens.sh
@@ -32,5 +32,6 @@ checkout_rpc_openstack
 configure_rpc_openstack
 ensure_osa_bootstrap
 prepare_queens
+repo_rebuild
 run_upgrade
 mark_completed

--- a/incremental/ubuntu16-upgrade-to-rocky.sh
+++ b/incremental/ubuntu16-upgrade-to-rocky.sh
@@ -32,5 +32,6 @@ checkout_rpc_openstack
 configure_rpc_openstack
 ensure_osa_bootstrap
 prepare_rocky
+repo_rebuild
 run_upgrade
 mark_completed

--- a/incremental/ubuntu18-upgrade-to-stein.sh
+++ b/incremental/ubuntu18-upgrade-to-stein.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018, Rackspace US, Inc.
+# Copyright 2019, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,28 +19,17 @@ set -evu
 source lib/functions.sh
 source lib/vars.sh
 
-require_ubuntu_version 16
+require_ubuntu_version 18
 
-export RPC_BRANCH=${RPC_BRANCH:-'ocata'}
-export RPC_PRODUCT_RELEASE="ocata"
-export OSA_SHA="stable/ocata"
-export SKIP_INSTALL=${SKIP_INSTALL:-"yes"}
+export OSA_SHA="stable/stein"
+export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
+export RPC_PRODUCT_RELEASE="stein"
+export RPC_ANSIBLE_VERSION="2.7.9"
 
+check_rpc_config
 mark_started
-
-# here we handle a lot of the cleanup from newton and rpc-o
-# to prepare for an OSA deploy
-prepare_ocata
-
-checkout_rpc_openstack
 checkout_openstack_ansible
 ensure_osa_bootstrap
-
-if [[ "$SKIP_INSTALL" == "yes" ]]; then
-  mark_completed
-  exit 0
-fi
-
-repo_rebuild
+prepare_stein
 run_upgrade
 mark_completed

--- a/incremental/ubuntu18-upgrade-to-train.sh
+++ b/incremental/ubuntu18-upgrade-to-train.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2018, Rackspace US, Inc.
+# Copyright 2019, Rackspace US, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,28 +19,17 @@ set -evu
 source lib/functions.sh
 source lib/vars.sh
 
-require_ubuntu_version 16
+require_ubuntu_version 18
 
-export RPC_BRANCH=${RPC_BRANCH:-'ocata'}
-export RPC_PRODUCT_RELEASE="ocata"
-export OSA_SHA="stable/ocata"
-export SKIP_INSTALL=${SKIP_INSTALL:-"yes"}
+export OSA_SHA="master"
+export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
+export RPC_PRODUCT_RELEASE="train"
+export RPC_ANSIBLE_VERSION="2.7.10"
 
+check_rpc_config
 mark_started
-
-# here we handle a lot of the cleanup from newton and rpc-o
-# to prepare for an OSA deploy
-prepare_ocata
-
-checkout_rpc_openstack
 checkout_openstack_ansible
 ensure_osa_bootstrap
-
-if [[ "$SKIP_INSTALL" == "yes" ]]; then
-  mark_completed
-  exit 0
-fi
-
-repo_rebuild
+prepare_train
 run_upgrade
 mark_completed


### PR DESCRIPTION
Adds initial support for upgrading to stein/train and treats rocky
as the upgrade point from Ubuntu 16.04 to 18.04 to test
with.  Anything being upgraded from 18.04 will make the
assumption that the rpc-config directory is required.

Rocky upgrades and up expect the rpc-config directory
to be present and setup (checks if /opt/rpc-config exists). If the /opt/rpc-config is not present, the upgrade will halt on stein/train upgrades.