### PR TITLE
Fix misspelling and incorrect syntax

### DIFF
--- a/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-elasticsearch.yml
+++ b/playbooks/roles/rpc_post_upgrade/tasks/post-upgrade-elasticsearch.yml
@@ -25,24 +25,24 @@
   pip:
     name: httplib2
 
-- name: Get elastic search indicies
+- name: Get elastic search indices
   uri:
     url: "http://{{ esurl }}/_cat/indices?v"
     return_content: "yes"
-  register: es_indicies
+  register: es_indices
 
-- name: debug es_indicies
-  debug: var=es_indicies
+- name: debug es_indices
+  debug: var=es_indices
 
-- name: Set ES indicies fact for processing
+- name: Set ES indices fact for processing
   set_fact:
-    es_indicies_list: "{{ es_indicies['content'].split('\n')[1:-1] }}"
+    es_indices_list: "{{ es_indices['content'].split('\n')[1:-1] }}"
 
-- name: debug es_indicies_list
-  debug: var=es_indicies_list
+- name: debug es_indices_list
+  debug: var=es_indices_list
 
 - name: Check ES for green health status
   debug:
-    var: "{{ item }}"
-  failed_when: "'green' not in \"{{ item }}\""
-  with_items: "{{ es_indicies_list|default([]) }}"
+    var: item
+  failed_when: "'green' not in item"
+  with_items: "{{ es_indices_list|default([]) }}"


### PR DESCRIPTION
This pull request fixes the basic problems with this check.  However, the bigger issue is, for a lot or even almost all of our environments, the status for indices is probably always going to be yellow since we're running stand alone ES nodes.  @sdhardy ran into this during the Pipedrive upgrade.  It was easy enough to fix with something like:

```for i in $(curl -s localhost:9200/_cat/indices?v | awk '{print $3}'); do curl -s -XPUT localhost:9200/${i}/_settings -d '{"index":{"number_of_replicas":0}}'; done```

But I'm not sure we're doing anything like this elsewhere before this check, so I imagine this check will fail in a lot of our environments.

Either way, these changes here should still be made.