### PR TITLE
Convert rsync tasks to one-time sync

### DIFF
--- a/scripts/pre_redeploy.sh
+++ b/scripts/pre_redeploy.sh
@@ -163,4 +163,7 @@ glance_registry_rolling: '100%'
 EOF
 
 # rsync group_vars from RPC-O repo
-rsync -av --delete ${RPCO_DEFAULT_FOLDER}/group_vars /etc/openstack_deploy/
+if [ ! -f "${UPGRADE_LEAP_MARKER_FOLDER}/rpco-group-vars-sync.complete" ]; then
+  rsync -av --delete ${RPCO_DEFAULT_FOLDER}/group_vars /etc/openstack_deploy/
+  touch "${UPGRADE_LEAP_MARKER_FOLDER}/rpco-group-vars-sync.complete"
+fi


### PR DESCRIPTION
The rsync tasks of the group vars is converted into a one-time
task to allow edits during upgrades without destroying these
upon restart