### PR TITLE
Adding missing delegation for rpc_pre_upgrade role

### DIFF
--- a/playbooks/roles/rpc_pre_upgrade/tasks/backup.yml
+++ b/playbooks/roles/rpc_pre_upgrade/tasks/backup.yml
@@ -31,6 +31,7 @@
   stat:
     path: '/usr/bin/innobackupex'
   register: innobackupex
+  delegate_to: "{{ groups['galera_all'][0] }}"
 
 - name: Set innobackupex utility
   set_fact:


### PR DESCRIPTION
The backup task did not include a delegation to determine the backup
program location when galera is running inside containers.
This fix includes the missing delegation.