### PR TITLE
Conditional setting of SKIP_CUSTOM_ENVD_CHECK

### DIFF
--- a/incremental/ubuntu18-upgrade-to-train.sh
+++ b/incremental/ubuntu18-upgrade-to-train.sh
@@ -26,6 +26,9 @@ export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
 export RPC_PRODUCT_RELEASE="train"
 export RPC_ANSIBLE_VERSION="2.8.8"
 
+# Skip OSA env.d check as RPC deploys custom env.d configurations
+test -f /etc/openstack_deploy/env.d/cephrgwdummy.yml 2>&1 && export SKIP_CUSTOM_ENVD_CHECK=true
+
 check_rpc_config
 mark_started
 checkout_openstack_ansible

--- a/incremental/ubuntu18-upgrade-to-ussuri.sh
+++ b/incremental/ubuntu18-upgrade-to-ussuri.sh
@@ -26,6 +26,9 @@ export SKIP_INSTALL=${SKIP_INSTALL:-'no'}
 export RPC_PRODUCT_RELEASE="ussuri"
 export RPC_ANSIBLE_VERSION="2.9.9"
 
+# Skip OSA env.d check as RPC deploys custom env.d configurations
+test -f /etc/openstack_deploy/env.d/cephrgwdummy.yml 2>&1 && export SKIP_CUSTOM_ENVD_CHECK=true
+
 check_rpc_config
 mark_started
 checkout_openstack_ansible


### PR DESCRIPTION
SKIP_CUSTOM_ENVD_CHECK is set to true when RPCO config templates
are present. This is generally the case since Stein